### PR TITLE
Save PDO exceptions.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -52,6 +52,8 @@ if test "$PHP_SKYWALKING_AGENT" != "no"; then
   cat >>Makefile.objects<< EOF
 all: cargo_build
 
+clean: cargo_clean
+
 cargo_build:
 	PHP_CONFIG=$PHP_PHP_CONFIG cargo build $CARGO_MODE_FLAGS
 	if [[ -f ./target/$CARGO_MODE_DIR/libskywalking_agent.dylib ]] ; then \\
@@ -59,7 +61,10 @@ cargo_build:
 	if [[ -f ./target/$CARGO_MODE_DIR/libskywalking_agent.so ]] ; then \\
 		cp ./target/$CARGO_MODE_DIR/libskywalking_agent.so ./modules/skywalking_agent.so ; fi
 
-.PHONY: cargo_build
+cargo_clean:
+	cargo clean
+
+.PHONY: cargo_build cargo_clean
 EOF
 
   AC_CONFIG_LINKS([ \

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -33,7 +33,7 @@ static RECEIVER: OnceCell<Mutex<Option<StdUnixStream>>> = OnceCell::new();
 pub fn init_channel() -> anyhow::Result<()> {
     let (sender, receiver) = StdUnixStream::pair()?;
 
-    sender.set_nonblocking(true)?;
+    sender.set_nonblocking(false)?;
     receiver.set_nonblocking(true)?;
 
     if SENDER.set(Mutex::new(sender)).is_err() {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -33,7 +33,7 @@ static RECEIVER: OnceCell<Mutex<Option<StdUnixStream>>> = OnceCell::new();
 pub fn init_channel() -> anyhow::Result<()> {
     let (sender, receiver) = StdUnixStream::pair()?;
 
-    sender.set_nonblocking(false)?;
+    sender.set_nonblocking(true)?;
     receiver.set_nonblocking(true)?;
 
     if SENDER.set(Mutex::new(sender)).is_err() {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -14,14 +14,16 @@
 // limitations under the License.
 
 use anyhow::{anyhow, bail, Context};
-use once_cell::sync::OnceCell;
+use once_cell::sync::{Lazy, OnceCell};
 use skywalking::reporter::{grpc::ColletcItemConsume, CollectItem, Report};
+use std::sync::mpsc;
 use std::{
     error::Error,
     io::{self, Write},
     mem::size_of,
     os::unix::net::UnixStream as StdUnixStream,
     sync::Mutex,
+    thread,
 };
 use tokio::{io::AsyncReadExt, net::UnixStream};
 use tonic::async_trait;
@@ -29,11 +31,23 @@ use tracing::error;
 
 static SENDER: OnceCell<Mutex<StdUnixStream>> = OnceCell::new();
 static RECEIVER: OnceCell<Mutex<Option<StdUnixStream>>> = OnceCell::new();
+static TX: Lazy<Mutex<mpsc::Sender<CollectItem>>> = Lazy::new(|| {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        for data in rx.into_iter() {
+            if let Err(err) = channel_send(data) {
+                error!(?err, "channel send failed");
+            }
+        }
+    });
+
+    Mutex::new(tx)
+});
 
 pub fn init_channel() -> anyhow::Result<()> {
     let (sender, receiver) = StdUnixStream::pair()?;
 
-    sender.set_nonblocking(true)?;
+    sender.set_nonblocking(false)?;
     receiver.set_nonblocking(true)?;
 
     if SENDER.set(Mutex::new(sender)).is_err() {
@@ -101,10 +115,18 @@ pub struct Reporter;
 
 impl Report for Reporter {
     fn report(&self, item: CollectItem) {
-        if let Err(err) = channel_send(item) {
-            error!(?err, "channel send failed");
+        if let Err(err) = tx_send(item) {
+            error!(?err, "tx send failed");
         }
     }
+}
+
+fn tx_send(data: CollectItem) -> anyhow::Result<()> {
+    TX.lock()
+        .map_err(|_| anyhow!("Get lock failed"))?
+        .send(data)?;
+
+    Ok(())
 }
 
 pub struct Consumer(UnixStream);

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -16,13 +16,12 @@
 use anyhow::{anyhow, bail, Context};
 use once_cell::sync::{Lazy, OnceCell};
 use skywalking::reporter::{grpc::ColletcItemConsume, CollectItem, Report};
-use std::sync::mpsc;
 use std::{
     error::Error,
     io::{self, Write},
     mem::size_of,
     os::unix::net::UnixStream as StdUnixStream,
-    sync::Mutex,
+    sync::{mpsc, Mutex},
     thread,
 };
 use tokio::{io::AsyncReadExt, net::UnixStream};

--- a/src/exception_frame.rs
+++ b/src/exception_frame.rs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use phper::sys;
 
 pub struct ExceptionFrame {

--- a/src/exception_frame.rs
+++ b/src/exception_frame.rs
@@ -14,10 +14,10 @@
 // limitations under the License.
 
 use phper::sys;
+use std::marker;
 
 pub struct ExceptionFrame {
-    #[allow(dead_code)]
-    not_matter: i32,
+    phantom: marker::PhantomData<isize>,
 }
 
 impl ExceptionFrame {
@@ -25,7 +25,9 @@ impl ExceptionFrame {
         unsafe {
             sys::zend_exception_save();
         }
-        ExceptionFrame { not_matter: 0 }
+        ExceptionFrame {
+            phantom: marker::PhantomData,
+        }
     }
 }
 

--- a/src/exception_frame.rs
+++ b/src/exception_frame.rs
@@ -1,0 +1,23 @@
+use phper::sys;
+
+pub struct ExceptionFrame {
+    #[allow(dead_code)]
+    not_matter: i32,
+}
+
+impl ExceptionFrame {
+    pub fn new() -> Self {
+        unsafe {
+            sys::zend_exception_save();
+        }
+        ExceptionFrame { not_matter: 0 }
+    }
+}
+
+impl Drop for ExceptionFrame {
+    fn drop(&mut self) {
+        unsafe {
+            sys::zend_exception_restore();
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 mod channel;
 mod component;
 mod context;
+mod exception_frame;
 mod execute;
 mod module;
 mod plugin;

--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -17,6 +17,7 @@ use super::Plugin;
 use crate::{
     component::COMPONENT_PHP_PDO_ID,
     context::RequestContext,
+    exception_frame::ExceptionFrame,
     execute::{get_this_mut, validate_num_args, AfterExecuteHook, BeforeExecuteHook, Noop},
 };
 use anyhow::Context;
@@ -206,6 +207,7 @@ fn after_hook(
 }
 
 fn after_hook_when_false(this: &mut ZObj, span: &mut Span) -> anyhow::Result<()> {
+    let _e = ExceptionFrame::new();
     let info = this.call("errorInfo", [])?;
     let info = info.as_z_arr().context("errorInfo isn't array")?;
 

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -390,6 +390,53 @@ segmentItems:
                 key: db.statement,
                 value: "SELECT * FROM `mysql`.`user` WHERE `User` = :user",
               }
+          - operationName: PDO->prepare
+            parentSpanId: 0
+            spanId: 8
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                key: db.data_source,
+                value: "dbname=skywalking;host=127.0.0.1;port=3306",
+              }
+              - {
+                key: db.statement,
+                value: "SELECT * FROM not_exist",
+              }
+          - operationName: PDOStatement->execute
+            parentSpanId: 0
+            spanId: 9
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: true
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                key: db.data_source,
+                value: "dbname=skywalking;host=127.0.0.1;port=3306",
+              }
+              - {
+                key: db.statement,
+                value: "SELECT * FROM not_exist",
+              }
+            logs:
+              - logEvent:
+                - { key: SQLSTATE, value: 42S02 }
+                - { key: Error Code, value: '1146' }
+                - { key: Error, value: "Table 'skywalking.not_exist' doesn't exist" }
           - operationName: GET:/pdo.php
             parentSpanId: -1
             spanId: 0

--- a/tests/php/fpm/pdo.php
+++ b/tests/php/fpm/pdo.php
@@ -41,4 +41,13 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
     Assert::same(count($rs), 0);
 }
 
+{
+    Assert::throws(function () {
+        $pdo = new PDO("mysql:dbname=skywalking;host=127.0.0.1;port=3306", "root", "password");
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $sth = $pdo->prepare("SELECT * FROM not_exist");
+        $sth->execute();
+    }, PDOException::class);
+}
+
 echo "ok";


### PR DESCRIPTION
A non-blocking sender fails with `EAGAIN`. And a `call_user_function` (`zend_call_function`) fails when exception is set.