### PR TITLE
Update minimal supported PHP version to 7.2.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,10 +52,6 @@ jobs:
           - macos-12
         version:
           # Many composer dependencies need PHP 7.2+
-          # - php: "7.0"
-          #   swoole: "4.3.6"
-          # - php: "7.1"
-          #   swoole: "4.5.11"
           - php: "7.2"
             swoole: "4.6.7"
           - php: "7.3"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Submit an [GitHub Issue](https://github.com/apache/skywalking/issues/new/choose)
 
 ## Installation Requirements
 
-SkyWalking PHP Agent requires SkyWalking 8.4+ and PHP 7.0+
+SkyWalking PHP Agent requires SkyWalking 8.4+ and PHP 7.2+
 
 ## Support List
 

--- a/docs/en/setup/service-agent/php-agent/README.md
+++ b/docs/en/setup/service-agent/php-agent/README.md
@@ -1,10 +1,17 @@
 # Setup PHP Agent
 
-1. Agent is available for PHP 7.0 - 8.x
+1. Agent is available for PHP 7.2 - 8.x
 2. Build from source
 3. Configure php.ini
 
 ## Requirements
+
+- GCC
+- Rustc
+- Cargo
+- Libclang
+- Make
+- Protoc
 
 For Debian-base OS:
 
@@ -12,13 +19,15 @@ For Debian-base OS:
 sudo apt install gcc make cargo libclang protobuf-compiler
 ```
 
-## Install from pecl.net
+## Install
+
+### Install from pecl.net
 
 ```shell script
-sudo pecl install skywalking_agent
+pecl install skywalking_agent
 ```
 
-## Build & install from source
+### Or install from source
 
 ```shell script
 git clone --recursive https://github.com/apache/skywalking-php.git

--- a/docs/en/setup/service-agent/php-agent/README.md
+++ b/docs/en/setup/service-agent/php-agent/README.md
@@ -27,7 +27,7 @@ sudo apt install gcc make cargo libclang protobuf-compiler
 pecl install skywalking_agent
 ```
 
-### Or install from source
+### install from the source codes
 
 ```shell script
 git clone --recursive https://github.com/apache/skywalking-php.git


### PR DESCRIPTION
Because our CI tests PHP version is greater than or equal to 7.2 (Many composer dependencies need PHP 7.2+).