### PR TITLE
Make explicit rust version requirement

### DIFF
--- a/docs/en/contribution/compiling.md
+++ b/docs/en/contribution/compiling.md
@@ -20,7 +20,7 @@ brew install php
 
 ## Install Rust Environment
 
-Install Rust globally.
+Install Rust 1.65.0+ globally.
 
 For Linux user:
 


### PR DESCRIPTION
I was facing Rustc error as 1.65+ is required. And I find out there is no rust 1.65 on brew(https://formulae.brew.sh/formula/rust). 

So, I have to follow Rust release blog(https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html), and use `rustup update stable` command to upgrade the rust version