### PR TITLE
Fix worker unexpected shutdown.

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -17,7 +17,7 @@ use crate::{
     channel::Reporter,
     execute::register_execute_functions,
     util::{get_sapi_module_name, IPS},
-    worker::{init_worker, shutdown_worker},
+    worker::init_worker,
     SKYWALKING_AGENT_ENABLE, SKYWALKING_AGENT_LOG_FILE, SKYWALKING_AGENT_LOG_LEVEL,
     SKYWALKING_AGENT_SERVICE_NAME, SKYWALKING_AGENT_SKYWALKING_VERSION,
 };
@@ -84,9 +84,7 @@ pub fn init() {
     register_execute_functions();
 }
 
-pub fn shutdown() {
-    shutdown_worker();
-}
+pub fn shutdown() {}
 
 fn init_logger() {
     let log_level = ini_get::<Option<&CStr>>(SKYWALKING_AGENT_LOG_LEVEL)


### PR DESCRIPTION
Fix worker unexpected shutdown problem mentioned in:

https://github.com/apache/skywalking/discussions/10260
https://github.com/apache/skywalking/discussions/10109

@burque98 @jmt33

The reason is that when the `pm` mode used by php-fpm is dynamic or ondemand, when the pool process exits, `MSHUTDOWN` will be called, and this hook will kill the worker process.

Now this action is removed, replace with `libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);`.

