### PR TITLE
Update docs about installing rust.

### DIFF
--- a/docs/en/contribution/compiling.md
+++ b/docs/en/contribution/compiling.md
@@ -20,14 +20,12 @@ brew install php
 
 ## Install Rust Environment
 
-Install Rust 1.65.0+ globally.
+Install Rust 1.65.0+.
 
 For Linux user:
 
 ```shell
-curl https://sh.rustup.rs -sSf | sudo sh -s -- --no-modify-path
-sudo ln -s /root/.cargo/bin/rustup /usr/local/bin/rustup
-sudo ln -s /root/.cargo/bin/cargo /usr/local/bin/cargo
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 For MacOS user:
@@ -41,7 +39,7 @@ brew install rust
 For Debian user:
 
 ```shell
-sudo apt install gcc make libclang protobuf-compiler
+sudo apt install gcc make llvm-dev libclang-dev clang protobuf-compiler
 ```
 
 For MacOS user:

--- a/docs/en/setup/service-agent/php-agent/README.md
+++ b/docs/en/setup/service-agent/php-agent/README.md
@@ -1,8 +1,8 @@
 # Setup PHP Agent
 
-1. Agent is available for PHP 7.2 - 8.x
-2. Build from source
-3. Configure php.ini
+1. Agent is available for PHP 7.2 - 8.x.
+2. Build from source.
+3. Configure `php.ini`.
 
 ## Requirements
 
@@ -15,8 +15,21 @@
 
 For Debian-base OS:
 
-```shell script
-sudo apt install gcc make cargo libclang protobuf-compiler
+```shell
+sudo apt install gcc make llvm-dev libclang-dev clang protobuf-compiler
+```
+
+### Install Rust globally
+
+*Refer to <https://forge.rust-lang.org/infra/other-installation-methods.html#standalone-installers>.*
+
+For linux x86_64 user:
+
+```shell
+wget https://static.rust-lang.org/dist/rust-1.65.0-x86_64-unknown-linux-gnu.tar.gz
+tar zxvf rust-1.65.0-x86_64-unknown-linux-gnu.tar.gz
+cd rust-1.65.0-x86_64-unknown-linux-gnu
+./install.sh
 ```
 
 ## Install


### PR DESCRIPTION
It is very unfriendly to use `rustup` to install Rust globally, so use standalone installer instead.

However, if it is a non-global installation, `rustup` is a good choice.

