### PR TITLE
Add configuration option `skywalking_agent.runtime_dir`.

### DIFF
--- a/docs/en/setup/service-agent/php-agent/README.md
+++ b/docs/en/setup/service-agent/php-agent/README.md
@@ -55,27 +55,31 @@ make install
 ## Configure php.ini
 
 ```ini
-[skywalking]
+[skywalking_agent]
 extension=skywalking_agent.so
 
-# Enable skywalking extension or not.
+; Enable skywalking_agent extension or not.
 skywalking_agent.enable = On
 
-# Log file path.
-skywalking_agent.log_file = /tmp/skywalking_agent.log
+; Log file path.
+skywalking_agent.log_file = /tmp/skywalking-agent.log
 
-# Log level: one of `OFF`, `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.
+; Log level: one of `OFF`, `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.
 skywalking_agent.log_level = INFO
 
-# Address of skywalking oap server.
+; Address of skywalking oap server.
 skywalking_agent.server_addr = http://0.0.0.0:11800
 
-# Application service name.
+; Application service name.
 skywalking_agent.service_name = hello-skywalking
 
-# Skywalking version.
+; Skywalking version.
 skywalking_agent.skywalking_version = 8
 
-# Skywalking worker threads, 0 will auto set as the cpu core size.
-# skywalking_agent.worker_threads = 3
+; Skywalking worker threads, 0 will auto set as the cpu core size,
+; default is 0.
+; skywalking_agent.worker_threads = 3
+
+; Skywalking agent runtime directory, default is /tmp/skywalking-agent.
+; skywalking_agent.runtime_dir = /tmp/skywalking-agent
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@ const SKYWALKING_AGENT_LOG_LEVEL: &str = "skywalking_agent.log_level";
 /// Log file of skywalking agent.
 const SKYWALKING_AGENT_LOG_FILE: &str = "skywalking_agent.log_file";
 
+/// Skywalking agent runtime directory.
+const SKYWALKING_AGENT_RUNTIME_DIR: &str = "skywalking_agent.runtime_dir";
+
 #[php_get_module]
 pub fn get_module() -> Module {
     let mut module = Module::new(
@@ -84,6 +87,11 @@ pub fn get_module() -> Module {
     module.add_ini(
         SKYWALKING_AGENT_LOG_FILE,
         "/tmp/skywalking-agent.log".to_string(),
+        Policy::System,
+    );
+    module.add_ini(
+        SKYWALKING_AGENT_RUNTIME_DIR,
+        "/tmp/skywalking-agent".to_string(),
         Policy::System,
     );
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -114,10 +114,10 @@ async fn start_worker(server_addr: String) -> anyhow::Result<()> {
     let mut sig_term = signal(SignalKind::terminate())?;
     let mut sig_int = signal(SignalKind::interrupt())?;
 
-    let socket_file = SOCKET_FILE_PATH.as_str();
+    let socket_file = &*SOCKET_FILE_PATH;
 
     let fut = async move {
-        debug!(socket_file, "Bind unix stream");
+        debug!(?socket_file, "Bind unix stream");
         let listener = UnixListener::bind(socket_file)?;
         change_permission(socket_file, 0o777);
 
@@ -242,7 +242,7 @@ impl Drop for WorkerExitGuard {
     fn drop(&mut self) {
         match Lazy::get(&SOCKET_FILE_PATH) {
             Some(socket_file) => {
-                info!(socket_file, "Remove socket file");
+                info!(?socket_file, "Remove socket file");
                 if let Err(err) = fs::remove_file(socket_file) {
                     error!(?err, "Remove socket file failed");
                 }


### PR DESCRIPTION
1. Add configuration option `skywalking_agent.runtime_dir`, indicate the runtime directory for holding sock files now.
2. Update the document about option.