### PR TITLE
Make the `SKYWALKING_AGENT_ENABLE` work in the request hook as well.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "skywalking-php"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 
 [package]
 name = "skywalking-php"
-version = "0.4.0"
+version = "0.5.0-dev"
 authors = ["Apache Software Foundation", "jmjoy <jmjoy@apache.org>", "Yanlong He <heyanlong@apache.org>"]
 description = "Apache SkyWalking PHP Agent."
 edition = "2021"

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -224,7 +224,7 @@ The text of each license is the standard Apache 2.0 license.
     https://crates.io/crates/prost-types/0.11.6 0.11.6 Apache-2.0
     https://crates.io/crates/scripts/0.0.0 0.0.0 Apache-2.0
     https://crates.io/crates/skywalking/0.6.0 0.6.0 Apache-2.0
-    https://crates.io/crates/skywalking-php/0.4.0 0.4.0 Apache-2.0
+    https://crates.io/crates/skywalking-php/0.5.0-dev 0.5.0-dev Apache-2.0
     https://crates.io/crates/sync_wrapper/0.1.1 0.1.1 Apache-2.0
 
 ========================================================================

--- a/src/request.rs
+++ b/src/request.rs
@@ -16,7 +16,7 @@
 use crate::{
     component::COMPONENT_PHP_ID,
     context::RequestContext,
-    module::{SKYWALKING_VERSION, is_enable},
+    module::{is_enable, SKYWALKING_VERSION},
     util::{catch_unwind_result, get_sapi_module_name, z_val_to_string},
 };
 use anyhow::{anyhow, Context};

--- a/src/request.rs
+++ b/src/request.rs
@@ -16,7 +16,7 @@
 use crate::{
     component::COMPONENT_PHP_ID,
     context::RequestContext,
-    module::SKYWALKING_VERSION,
+    module::{SKYWALKING_VERSION, is_enable},
     util::{catch_unwind_result, get_sapi_module_name, z_val_to_string},
 };
 use anyhow::{anyhow, Context};
@@ -34,6 +34,9 @@ use tracing::{error, instrument, trace, warn};
 
 #[instrument(skip_all)]
 pub fn init() {
+    if !is_enable() {
+        return;
+    }
     if get_sapi_module_name().to_bytes() == b"fpm-fcgi" {
         if let Err(err) = catch_unwind_result(request_init_for_fpm) {
             error!(mode = "fpm", ?err, "request init failed");
@@ -43,6 +46,9 @@ pub fn init() {
 
 #[instrument(skip_all)]
 pub fn shutdown() {
+    if !is_enable() {
+        return;
+    }
     if get_sapi_module_name().to_bytes() == b"fpm-fcgi" {
         if let Err(err) = catch_unwind_result(request_shutdown_for_fpm) {
             error!(mode = "fpm", ?err, "request shutdown failed");


### PR DESCRIPTION
1. Previously, the `SKYWALKING_AGENT_ENABLE` was only used in the module hook, if disabled, there is an error log for each request.

   This PR make the `SKYWALKING_AGENT_ENABLE` work in the request hook as well.

2. Start 0.5.0 dev.