### PR TITLE
Fix parent endpoint and peer in segment ref and tag url in entry span.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -49,4 +49,9 @@ impl RequestContext {
     ) -> anyhow::Result<T> {
         Self::try_with_global(request_id, |ctx| f(&mut ctx.tracing_context))
     }
+
+    /// Primary endpoint name is used for endpoint dependency.
+    pub fn get_primary_span(&self) -> &Span {
+        &self.entry_span
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,3 +31,9 @@ impl From<Utf8Error> for Error {
         Self::Anyhow(e.into())
     }
 }
+
+impl From<url::ParseError> for Error {
+    fn from(e: url::ParseError) -> Self {
+        Self::Anyhow(e.into())
+    }
+}

--- a/src/plugin/plugin_curl.rs
+++ b/src/plugin/plugin_curl.rs
@@ -404,8 +404,13 @@ impl CurlPlugin {
     }
 
     fn inject_sw_header(request_id: Option<i64>, ch: ZVal, info: &CurlInfo) -> crate::Result<()> {
-        let sw_header = RequestContext::try_with_global_ctx(request_id, |ctx| {
-            Ok(encode_propagation(ctx, info.url.path(), &info.peer))
+        let sw_header = RequestContext::try_with_global(request_id, |req_ctx| {
+            let span_object = req_ctx.entry_span.span_object();
+            Ok(encode_propagation(
+                &req_ctx.tracing_context,
+                &span_object.operation_name,
+                &span_object.peer,
+            ))
         })?;
         let mut val = CURL_HEADERS
             .with(|headers| headers.borrow_mut().remove(&info.cid))

--- a/src/plugin/plugin_curl.rs
+++ b/src/plugin/plugin_curl.rs
@@ -405,7 +405,7 @@ impl CurlPlugin {
 
     fn inject_sw_header(request_id: Option<i64>, ch: ZVal, info: &CurlInfo) -> crate::Result<()> {
         let sw_header = RequestContext::try_with_global(request_id, |req_ctx| {
-            let span_object = req_ctx.entry_span.span_object();
+            let span_object = req_ctx.get_primary_span().span_object();
             Ok(encode_propagation(
                 &req_ctx.tracing_context,
                 &span_object.operation_name,

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -36,8 +36,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /index.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/curl.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -64,8 +64,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /curl.test.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/curl.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 2,
                   parentTraceSegmentId: "not null",
@@ -92,8 +92,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /curl.test.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/curl.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 3,
                   parentTraceSegmentId: "not null",
@@ -120,8 +120,8 @@ segmentItems:
               - { key: http.status_code, value: "404" }
             refs:
               - {
-                  parentEndpoint: /not-exists.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/curl.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 4,
                   parentTraceSegmentId: "not null",
@@ -148,8 +148,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /index.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/guzzle.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -263,8 +263,8 @@ segmentItems:
               - { key: http.status_code, value: "404" }
             refs:
               - {
-                  parentEndpoint: /not-exists.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/curl-multi.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 3,
                   parentTraceSegmentId: "not null",
@@ -291,8 +291,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /curl.test.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/curl-multi.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -319,8 +319,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /curl.test.php,
-                  networkAddress: "127.0.0.1:9011",
+                  parentEndpoint: "GET:/curl-multi.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 2,
                   parentTraceSegmentId: "not null",
@@ -1022,8 +1022,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /guzzle.php,
-                  networkAddress: "127.0.0.1:9012",
+                  parentEndpoint: "GET:/curl.enter.php",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 5,
                   parentTraceSegmentId: "not null",
@@ -1053,8 +1053,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /,
-                  networkAddress: "127.0.0.1:9501",
+                  parentEndpoint: "GET:/curl",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -1129,8 +1129,8 @@ segmentItems:
               - { key: http.status_code, value: "200" }
             refs:
               - {
-                  parentEndpoint: /,
-                  networkAddress: "127.0.0.1:9502",
+                  parentEndpoint: "GET:/curl",
+                  networkAddress: "",
                   refType: CrossProcess,
                   parentSpanId: 2,
                   parentTraceSegmentId: "not null",

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -31,7 +31,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /index.php }
+              - { key: url, value: "http://127.0.0.1:9011/index.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
             refs:
@@ -59,7 +59,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /curl.test.php }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?single=1",
+                }
               - { key: http.method, value: POST }
               - { key: http.status_code, value: "200" }
             refs:
@@ -87,7 +90,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /curl.test.php }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?single=2",
+                }
               - { key: http.method, value: POST }
               - { key: http.status_code, value: "200" }
             refs:
@@ -115,7 +121,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /not-exists.php }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/not-exists.php?single=3",
+                }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "404" }
             refs:
@@ -143,7 +152,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /index.php }
+              - { key: url, value: "http://127.0.0.1:9011/index.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
             refs:
@@ -185,7 +194,10 @@ segmentItems:
             peer: 127.0.0.1:9011
             skipAnalysis: false
             tags:
-              - { key: url, value: "http://127.0.0.1:9011/curl.test.php" }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?single=1",
+                }
               - { key: status_code, value: "200" }
           - operationName: /curl.test.php
             parentSpanId: 0
@@ -199,7 +211,10 @@ segmentItems:
             peer: 127.0.0.1:9011
             skipAnalysis: false
             tags:
-              - { key: url, value: "http://127.0.0.1:9011/curl.test.php" }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?single=2",
+                }
               - { key: status_code, value: "200" }
           - operationName: /not-exists.php
             parentSpanId: 0
@@ -213,7 +228,10 @@ segmentItems:
             peer: 127.0.0.1:9011
             skipAnalysis: false
             tags:
-              - { key: url, value: "http://127.0.0.1:9011/not-exists.php" }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/not-exists.php?single=3",
+                }
               - { key: status_code, value: "500" }
           - operationName: /guzzle.php
             parentSpanId: 0
@@ -241,7 +259,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /curl.enter.php }
+              - { key: url, value: "http://127.0.0.1:9011/curl.enter.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
@@ -258,7 +276,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /not-exists.php }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/not-exists.php?multi=3",
+                }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "404" }
             refs:
@@ -286,7 +307,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /curl.test.php }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?multi=1",
+                }
               - { key: http.method, value: POST }
               - { key: http.status_code, value: "200" }
             refs:
@@ -314,7 +338,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /curl.test.php }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?multi=2",
+                }
               - { key: http.method, value: POST }
               - { key: http.status_code, value: "200" }
             refs:
@@ -342,7 +369,10 @@ segmentItems:
             peer: 127.0.0.1:9011
             skipAnalysis: false
             tags:
-              - { key: url, value: "http://127.0.0.1:9011/not-exists.php" }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/not-exists.php?multi=3",
+                }
               - { key: status_code, value: "500" }
           - operationName: /curl.test.php
             parentSpanId: 0
@@ -356,7 +386,10 @@ segmentItems:
             peer: 127.0.0.1:9011
             skipAnalysis: false
             tags:
-              - { key: url, value: "http://127.0.0.1:9011/curl.test.php" }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?multi=2",
+                }
               - { key: status_code, value: "200" }
           - operationName: /curl.test.php
             parentSpanId: 0
@@ -370,7 +403,10 @@ segmentItems:
             peer: 127.0.0.1:9011
             skipAnalysis: false
             tags:
-              - { key: url, value: "http://127.0.0.1:9011/curl.test.php" }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl.test.php?multi=1",
+                }
               - { key: status_code, value: "200" }
           - operationName: GET:/curl-multi.enter.php
             parentSpanId: -1
@@ -384,7 +420,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /curl-multi.enter.php }
+              - {
+                  key: url,
+                  value: "http://127.0.0.1:9011/curl-multi.enter.php",
+                }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
@@ -592,7 +631,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /pdo.php }
+              - { key: url, value: "http://127.0.0.1:9011/pdo.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
@@ -671,7 +710,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /predis.php }
+              - { key: url, value: "http://127.0.0.1:9011/predis.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
       - segmentId: 'not null'
@@ -722,10 +761,10 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - {key: url, value: /mysqli.php}
-              - {key: http.method, value: GET}
-              - {key: http.status_code, value: '200'}
-      - segmentId: 'not null'
+              - { key: url, value: "http://127.0.0.1:9011/mysqli.php" }
+              - { key: http.method, value: GET }
+              - { key: http.status_code, value: "200" }
+      - segmentId: "317420675919366046582542286930754598201"
         spans:
           - operationName: Memcached->set
             parentSpanId: 0
@@ -838,7 +877,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /memcached.php }
+              - { key: url, value: "http://127.0.0.1:9011/memcached.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
@@ -930,7 +969,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /redis.succ.php }
+              - { key: url, value: "http://127.0.0.1:9011/redis.succ.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
@@ -983,7 +1022,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /redis.fail.php }
+              - { key: url, value: "http://127.0.0.1:9011/redis.fail.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
   - serviceName: skywalking-agent-test-2
@@ -1017,7 +1056,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /guzzle.php }
+              - { key: url, value: "http://127.0.0.1:9012/guzzle.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
             refs:
@@ -1048,7 +1087,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: / }
+              - { key: url, value: "http://127.0.0.1:9501/?swoole=1" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
             refs:
@@ -1076,7 +1115,7 @@ segmentItems:
             peer: 127.0.0.1:9501
             skipAnalysis: false
             tags:
-              - { key: url, value: "http://127.0.0.1:9501/" }
+              - { key: url, value: "http://127.0.0.1:9501/?swoole=1" }
               - { key: status_code, value: "200" }
           - operationName: /
             parentSpanId: 0
@@ -1104,7 +1143,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: /curl }
+              - { key: url, value: "http://127.0.0.1:9501/curl" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
   - serviceName: skywalking-agent-test-2-swoole
@@ -1124,7 +1163,7 @@ segmentItems:
             peer: ""
             skipAnalysis: false
             tags:
-              - { key: url, value: / }
+              - { key: url, value: "http://127.0.0.1:9502/" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
             refs:

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -764,7 +764,7 @@ segmentItems:
               - { key: url, value: "http://127.0.0.1:9011/mysqli.php" }
               - { key: http.method, value: GET }
               - { key: http.status_code, value: "200" }
-      - segmentId: "317420675919366046582542286930754598201"
+      - segmentId: 'not null'
         spans:
           - operationName: Memcached->set
             parentSpanId: 0

--- a/tests/php/fpm/curl-multi.enter.php
+++ b/tests/php/fpm/curl-multi.enter.php
@@ -28,7 +28,7 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
         [
             'curl' => (function () {
                 $ch = curl_init();
-                curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/curl.test.php");
+                curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/curl.test.php?multi=1");
                 curl_setopt($ch, CURLOPT_TIMEOUT, 10);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($ch, CURLOPT_POST, 1);
@@ -44,7 +44,7 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
             'curl' => (function () {
                 $ch = curl_init();
                 curl_setopt_array($ch, [
-                    CURLOPT_URL => "http://127.0.0.1:9011/curl.test.php",
+                    CURLOPT_URL => "http://127.0.0.1:9011/curl.test.php?multi=2",
                     CURLOPT_TIMEOUT => 10,
                     CURLOPT_RETURNTRANSFER => 1,
                     CURLOPT_POST => 1,
@@ -60,7 +60,7 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
         [
             'curl' => (function () {
                 $ch = curl_init();
-                curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/not-exists.php");
+                curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/not-exists.php?multi=3");
                 curl_setopt($ch, CURLOPT_TIMEOUT, 10);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($ch, CURLOPT_HEADER, 0);

--- a/tests/php/fpm/curl.enter.php
+++ b/tests/php/fpm/curl.enter.php
@@ -32,7 +32,7 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
 
 {
     $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/curl.test.php");
+    curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/curl.test.php?single=1");
     curl_setopt($ch, CURLOPT_TIMEOUT, 10);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_POST, 1);
@@ -46,7 +46,7 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
 {
     $ch = curl_init();
     curl_setopt_array($ch, [
-        CURLOPT_URL => "http://127.0.0.1:9011/curl.test.php",
+        CURLOPT_URL => "http://127.0.0.1:9011/curl.test.php?single=2",
         CURLOPT_TIMEOUT => 10,
         CURLOPT_RETURNTRANSFER => 1,
         CURLOPT_POST => 1,
@@ -60,7 +60,7 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
 
 {
     $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/not-exists.php");
+    curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9011/not-exists.php?single=3");
     curl_setopt($ch, CURLOPT_TIMEOUT, 10);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_HEADER, 0);

--- a/tests/php/swoole/main.1.php
+++ b/tests/php/swoole/main.1.php
@@ -43,7 +43,7 @@ $http->on('request', function ($request, $response) {
         case "/curl":
             {
                 $ch = curl_init();
-                curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9501/");
+                curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:9501/?swoole=1");
                 curl_setopt($ch, CURLOPT_TIMEOUT, 10);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($ch, CURLOPT_HEADER, 0);


### PR DESCRIPTION
1. Fix parent endpoint and peer in segment ref. In the past, the parent endpoint and peer of the sw8 header uses the endpoint and peer of the exit span by mistake (but it does not seem to affect the display of tracing on the UI).
3. Fix tag url in entry span. 