### PR TITLE
Log Exception in tracing span when throw.

### DIFF
--- a/src/plugin/plugin_amqplib.rs
+++ b/src/plugin/plugin_amqplib.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Plugin;
+use super::{log_exception, Plugin};
 use crate::{
     component::COMPONENT_AMQP_PRODUCER_ID,
     context::{RequestContext, SW_HEADER},
-    execute::{get_this_mut, validate_num_args, AfterExecuteHook, BeforeExecuteHook, Noop},
+    execute::{get_this_mut, validate_num_args, AfterExecuteHook, BeforeExecuteHook},
     tag::{TAG_MQ_BROKER, TAG_MQ_QUEUE, TAG_MQ_TOPIC},
 };
 use anyhow::Context;
@@ -99,7 +99,11 @@ impl AmqplibPlugin {
 
                 Ok(Box::new(span))
             }),
-            Noop::noop(),
+            Box::new(move |_, span, _, _| {
+                let mut span = span.downcast::<Span>().unwrap();
+                log_exception(&mut span);
+                Ok(())
+            }),
         )
     }
 

--- a/src/plugin/plugin_curl.rs
+++ b/src/plugin/plugin_curl.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Plugin;
+use super::{log_exception, Plugin};
 use crate::{
     component::COMPONENT_PHP_CURL_ID,
     context::{RequestContext, SW_HEADER},
@@ -442,6 +442,7 @@ impl CurlPlugin {
             .and_then(|code| code.as_long())
             .context("Call curl_getinfo, http_code is null")?;
         span.add_tag("status_code", &*http_code.to_string());
+
         if http_code == 0 {
             let result = call("curl_error", &mut [ch.clone()])?;
             let curl_error = result
@@ -456,6 +457,9 @@ impl CurlPlugin {
         } else {
             span.span_object_mut().is_error = false;
         }
+
+        log_exception(span);
+
         Ok(())
     }
 }

--- a/src/plugin/plugin_memcached.rs
+++ b/src/plugin/plugin_memcached.rs
@@ -15,7 +15,7 @@
 
 use std::{any::Any, collections::HashMap};
 
-use super::Plugin;
+use super::{log_exception, Plugin};
 use crate::{
     component::COMPONENT_PHP_MEMCACHED_ID,
     context::RequestContext,
@@ -306,6 +306,7 @@ fn after_hook(
     _: Option<i64>, span: Box<dyn Any>, execute_data: &mut ExecuteData, return_value: &mut ZVal,
 ) -> crate::Result<()> {
     let mut span = span.downcast::<Span>().expect("Downcast to Span failed");
+
     if let Some(b) = return_value.as_bool() {
         if !b {
             span.span_object_mut().is_error = true;
@@ -330,6 +331,9 @@ fn after_hook(
             }
         }
     }
+
+    log_exception(&mut span);
+
     Ok(())
 }
 

--- a/src/plugin/plugin_predis.rs
+++ b/src/plugin/plugin_predis.rs
@@ -18,6 +18,7 @@ use crate::{
     component::COMPONENT_PHP_PREDIS_ID,
     context::RequestContext,
     execute::{get_this_mut, validate_num_args, AfterExecuteHook, BeforeExecuteHook},
+    plugin::log_exception,
     tag::{TAG_CACHE_CMD, TAG_CACHE_KEY, TAG_CACHE_OP, TAG_CACHE_TYPE},
 };
 use once_cell::sync::Lazy;
@@ -237,6 +238,8 @@ impl PredisPlugin {
                 if !exception.is_null() || typ.is_false() {
                     span.span_object_mut().is_error = true;
                 }
+
+                log_exception(&mut span);
 
                 Ok(())
             }),

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -428,9 +428,26 @@ segmentItems:
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
         spans:
-          - operationName: PDO->exec
+          - operationName: PDO->__construct
             parentSpanId: 0
             spanId: 1
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                  key: db.data_source,
+                  value: dbname=skywalking;host=127.0.0.1;port=3306,
+                }
+          - operationName: PDO->exec
+            parentSpanId: 0
+            spanId: 2
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -446,28 +463,7 @@ segmentItems:
                   value: "dbname=skywalking;host=127.0.0.1;port=3306",
                 }
               - { key: db.statement, value: SELECT 1 }
-          - operationName: PDO->prepare
-            parentSpanId: 0
-            spanId: 2
-            spanLayer: Database
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 8003
-            isError: false
-            spanType: Exit
-            peer: 127.0.0.1:3306
-            skipAnalysis: false
-            tags:
-              - { key: db.type, value: mysql }
-              - {
-                  key: db.data_source,
-                  value: "dbname=skywalking;host=127.0.0.1:3306",
-                }
-              - {
-                  key: db.statement,
-                  value: "SELECT * FROM `mysql`.`user` WHERE `User` = :user",
-                }
-          - operationName: PDOStatement->execute
+          - operationName: PDO->__construct
             parentSpanId: 0
             spanId: 3
             spanLayer: Database
@@ -484,11 +480,7 @@ segmentItems:
                   key: db.data_source,
                   value: "dbname=skywalking;host=127.0.0.1:3306",
                 }
-              - {
-                  key: db.statement,
-                  value: "SELECT * FROM `mysql`.`user` WHERE `User` = :user",
-                }
-          - operationName: PDOStatement->fetchAll
+          - operationName: PDO->prepare
             parentSpanId: 0
             spanId: 4
             spanLayer: Database
@@ -509,9 +501,68 @@ segmentItems:
                   key: db.statement,
                   value: "SELECT * FROM `mysql`.`user` WHERE `User` = :user",
                 }
-          - operationName: PDO->prepare
+          - operationName: PDOStatement->execute
             parentSpanId: 0
             spanId: 5
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                  key: db.data_source,
+                  value: "dbname=skywalking;host=127.0.0.1:3306",
+                }
+              - {
+                  key: db.statement,
+                  value: "SELECT * FROM `mysql`.`user` WHERE `User` = :user",
+                }
+          - operationName: PDOStatement->fetchAll
+            parentSpanId: 0
+            spanId: 6
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                  key: db.data_source,
+                  value: "dbname=skywalking;host=127.0.0.1:3306",
+                }
+              - {
+                  key: db.statement,
+                  value: "SELECT * FROM `mysql`.`user` WHERE `User` = :user",
+                }
+          - operationName: PDO->__construct
+            parentSpanId: 0
+            spanId: 7
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                  key: db.data_source,
+                  value: "dbname=skywalking;host=127.0.0.1:3306;",
+                }
+          - operationName: PDO->prepare
+            parentSpanId: 0
+            spanId: 8
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -532,7 +583,7 @@ segmentItems:
               }
           - operationName: PDOStatement->execute
             parentSpanId: 0
-            spanId: 6
+            spanId: 9
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -553,7 +604,7 @@ segmentItems:
               }
           - operationName: PDOStatement->fetchAll
             parentSpanId: 0
-            spanId: 7
+            spanId: 10
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -572,9 +623,26 @@ segmentItems:
                 key: db.statement,
                 value: "SELECT * FROM `mysql`.`user` WHERE `User` = :user",
               }
+          - operationName: PDO->__construct
+            parentSpanId: 0
+            spanId: 11
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                  key: db.data_source,
+                  value: dbname=skywalking;host=127.0.0.1;port=3306,
+                }
           - operationName: PDO->prepare
             parentSpanId: 0
-            spanId: 8
+            spanId: 12
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -595,7 +663,7 @@ segmentItems:
               }
           - operationName: PDOStatement->execute
             parentSpanId: 0
-            spanId: 9
+            spanId: 13
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -715,9 +783,22 @@ segmentItems:
               - { key: http.status_code, value: "200" }
       - segmentId: 'not null'
         spans:
-          - operationName: mysqli->query
+          - operationName: mysqli->__construct
             parentSpanId: 0
             spanId: 1
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8004
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+          - operationName: mysqli->query
+            parentSpanId: 0
+            spanId: 2
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -732,9 +813,22 @@ segmentItems:
                   key: db.statement,
                   value: "SELECT 1",
                 }
+          - operationName: mysqli->__construct
+            parentSpanId: 0
+            spanId: 3
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8004
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
           - operationName: mysqli->query
             parentSpanId: 0
-            spanId: 2
+            spanId: 4
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -1005,11 +1099,9 @@ segmentItems:
               - { key: cache.key, value: foo }
             logs:
               - logEvent:
-                  - { key: Exception Class, value: RedisException }
-                  - {
-                      key: Exception Message,
-                      value: NOAUTH Authentication required.,
-                    }
+                  - { key: error.kind, value: RedisException }
+                  - { key: message, value: NOAUTH Authentication required. }
+                  - { key: stack, value: not null }
           - operationName: GET:/redis.fail.php
             parentSpanId: -1
             spanId: 0
@@ -1300,9 +1392,26 @@ segmentItems:
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
         spans:
-          - operationName: PDO->exec
+          - operationName: PDO->__construct
             parentSpanId: 0
             spanId: 1
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8003
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+              - {
+                  key: db.data_source,
+                  value: dbname=skywalking;host=127.0.0.1;port=3306,
+                }
+          - operationName: PDO->exec
+            parentSpanId: 0
+            spanId: 2
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0
@@ -1335,9 +1444,22 @@ segmentItems:
               - { key: http.status_code, value: "200" }
       - segmentId: "not null"
         spans:
-          - operationName: mysqli->query
+          - operationName: mysqli->__construct
             parentSpanId: 0
             spanId: 1
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8004
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+          - operationName: mysqli->query
+            parentSpanId: 0
+            spanId: 2
             spanLayer: Database
             startTime: gt 0
             endTime: gt 0


### PR DESCRIPTION
1. Log `Exception` after calling the hooked function/method, if it throw.
  
    ![image](https://github.com/apache/skywalking-php/assets/8677974/a36aeb2b-b1ab-417c-addb-76239b05ab54)


2. Add `PDO::__construct` and `mysqli::__construct` in spans, because they are possible to throw Exception.