### PR TITLE
Fix hook for Doctrine PDO class

### DIFF
--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -201,6 +201,9 @@ fn after_hook(
         if obj.get_class().get_name() == &"PDOStatement" {
             return after_hook_when_pdo_statement(get_this_mut(execute_data)?, obj);
         }
+        else if obj.get_class().get_name() == &"Doctrine\\DBAL\\Driver\\PDOStatement" {
+            return after_hook_when_pdo_statement(get_this_mut(execute_data)?, obj);
+        }
     }
 
     Ok(())

--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -50,9 +50,7 @@ impl Plugin for PdoPlugin {
     }
 
     fn hook(
-        &self,
-        class_name: Option<&str>,
-        function_name: &str,
+        &self, class_name: Option<&str>, function_name: &str,
     ) -> Option<(
         Box<crate::execute::BeforeExecuteHook>,
         Box<crate::execute::AfterExecuteHook>,
@@ -108,8 +106,7 @@ impl PdoPlugin {
     }
 
     fn hook_pdo_methods(
-        &self,
-        function_name: &str,
+        &self, function_name: &str,
     ) -> (Box<BeforeExecuteHook>, Box<AfterExecuteHook>) {
         let function_name = function_name.to_owned();
         (
@@ -135,8 +132,7 @@ impl PdoPlugin {
     }
 
     fn hook_pdo_statement_methods(
-        &self,
-        function_name: &str,
+        &self, function_name: &str,
     ) -> (Box<BeforeExecuteHook>, Box<AfterExecuteHook>) {
         let function_name = function_name.to_owned();
         (
@@ -193,10 +189,7 @@ unsafe extern "C" fn dtor(object: *mut sys::zend_object) {
 }
 
 fn after_hook(
-    _: Option<i64>,
-    span: Box<dyn Any>,
-    execute_data: &mut ExecuteData,
-    return_value: &mut ZVal,
+    _: Option<i64>, span: Box<dyn Any>, execute_data: &mut ExecuteData, return_value: &mut ZVal,
 ) -> crate::Result<()> {
     if let Some(b) = return_value.as_bool() {
         if !b {
@@ -261,10 +254,7 @@ fn get_error_info_item(info: &ZArr, i: u64) -> anyhow::Result<&ZVal> {
 }
 
 fn create_exit_span_with_dsn(
-    request_id: Option<i64>,
-    class_name: &str,
-    function_name: &str,
-    dsn: &Dsn,
+    request_id: Option<i64>, class_name: &str, function_name: &str, dsn: &Dsn,
 ) -> anyhow::Result<Span> {
     RequestContext::try_with_global_ctx(request_id, |ctx| {
         let mut span =

--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -199,7 +199,6 @@ fn after_hook(
         }
     } else if let Some(obj) = return_value.as_mut_z_obj() {
         let cls=obj.get_class().get_name().to_str()?;
-        debug!(cls, "returned class in after_hook");
         match cls {
             "PDOStatement" => {
                 return after_hook_when_pdo_statement(get_this_mut(execute_data)?, obj);

--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -279,7 +279,7 @@ fn with_dsn<T>(handle: u32, f: impl FnOnce(&Dsn) -> anyhow::Result<T>) -> anyhow
     DSN_MAP
         .get(&handle)
         .map(|r| f(r.value()))
-        .context("dns not exists")?
+        .context("dsn not exists")?
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
When using doctrine the return type of PDO->prepare is Doctrine\DBAL\Driver\PDO\Statement and the hook didn't work. Changed the if to a match statement and added a bunch of debug statements. Fixed a minor typo.