### PR TITLE
Upgrade dependencies and adapt.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,44 +45,94 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -84,9 +143,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.11"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -116,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -185,7 +244,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
  "which",
 ]
 
@@ -222,15 +281,15 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytesize"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
 name = "cc"
@@ -260,11 +319,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -292,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -303,40 +359,45 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codespan-reporting"
@@ -347,6 +408,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "convert_case"
@@ -366,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -413,7 +480,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -430,7 +497,7 @@ checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -462,7 +529,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -505,18 +572,18 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -542,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -587,53 +654,53 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -658,20 +725,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -685,7 +752,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log",
@@ -705,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -742,6 +809,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hostname"
@@ -799,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -910,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -929,12 +1002,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -957,14 +1031,14 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -978,15 +1052,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1005,9 +1079,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -1042,9 +1116,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -1100,9 +1174,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1121,14 +1195,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "wasi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1157,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1200,15 +1274,15 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -1242,7 +1316,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1265,12 +1339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,15 +1356,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1350,7 +1418,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1366,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1415,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "phper"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca4911bd7afcc27563c8c71fee774200efe3466b91ef267eed9fe786465a56c"
+checksum = "d1cce79265fa70f2a6f5f11cf4f694e962f437575dee2001549c19b9489fb630"
 dependencies = [
  "derive_more",
  "indexmap",
@@ -1431,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "phper-alloc"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e459b21c04d72e5f9ae95483e49165acfeb5c24fff2b9021118107be1b963dfe"
+checksum = "fddab68605152a829badc546b4f8abb27ab11d6e2dce01cafb24c7bc3eca82e6"
 dependencies = [
  "phper-build",
  "phper-sys",
@@ -1441,29 +1509,29 @@ dependencies = [
 
 [[package]]
 name = "phper-build"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88285cabb005695e8fb009926d1e54b8be7d0b293b8eb2c3271dd75cce706ad0"
+checksum = "46c6249b9453daa38a626069a7586d3350d6f9cd6d94b91d6e80aa350af7034d"
 dependencies = [
  "phper-sys",
 ]
 
 [[package]]
 name = "phper-macros"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7058f7a91da7bac48e076d8c985c5f264c062dee9b1fc06f4439f67426594168"
+checksum = "221c5c2f04e8dcba9dee646b79fd17ef4c1a64b4b32575662cbfdfebfde9fd7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "phper-sys"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb326355ebedca7f81fb65be596365f0b5f52d8a85197047ff4186c97f68fde9"
+checksum = "b2538b854618f97f39c0612a9ad97c5980b8d6f32d3a01a9de605851dcaf9507"
 dependencies = [
  "bindgen",
  "cc",
@@ -1471,22 +1539,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1509,9 +1577,18 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
+dependencies = [
+ "portable-atomic 1.3.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
 
 [[package]]
 name = "ppv-lite86"
@@ -1521,52 +1598,28 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1574,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -1589,31 +1642,30 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -1625,9 +1677,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1672,27 +1724,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.1"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "aho-corasick",
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [
+ "aho-corasick 1.0.1",
  "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -1755,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1776,16 +1837,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1811,15 +1872,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -1889,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1899,35 +1960,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.155"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.155"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1937,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
 dependencies = [
  "serde",
 ]
@@ -1984,9 +2045,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -1999,9 +2060,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "skywalking"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df0d94ba57de62d094dc1c00f3b20e1528c66c5b267df7d35da250982e3670b"
+checksum = "52aa801db00a7a2f2ae6e3b5635fc148da7eea7727c020e454424688b0a507c1"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -2011,7 +2072,7 @@ dependencies = [
  "hostname",
  "once_cell",
  "parking_lot",
- "portable-atomic",
+ "portable-atomic 0.3.20",
  "prost",
  "prost-derive",
  "serde",
@@ -2032,7 +2093,6 @@ dependencies = [
  "anyhow",
  "axum",
  "bincode",
- "chrono",
  "dashmap",
  "fastcgi-client",
  "futures-util",
@@ -2056,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -2080,9 +2140,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -2112,10 +2172,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.1"
+name = "syn"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "systemstat"
@@ -2127,28 +2198,28 @@ dependencies = [
  "lazy_static",
  "libc",
  "nom",
- "time 0.3.17",
+ "time",
  "winapi",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "tera"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27df4164dd125228af4c90c9799a29740e39151767d579f3fc711491054a0378"
+checksum = "95a665751302f22a03c56721e23094e4dc22b04a80f381e6737a07bf7a7c70c0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2178,22 +2249,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2207,20 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "serde",
  "time-core",
@@ -2228,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tinyvec"
@@ -2249,14 +2309,13 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -2264,7 +2323,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2279,13 +2338,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2311,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2322,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2378,7 +2437,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2428,20 +2487,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2470,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -2612,9 +2671,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -2649,10 +2708,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.2.2"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
  "serde",
@@ -2699,21 +2764,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2721,24 +2780,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2748,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2758,22 +2817,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "wasm-streams"
@@ -2862,13 +2921,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2877,65 +2936,131 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,28 +36,27 @@ name = "skywalking_agent"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-anyhow = { version = "1.0.69", features = ["backtrace"] }
+anyhow = { version = "1.0.71", features = ["backtrace"] }
 bincode = "1.3.3"
-chrono = "0.4.24"
 dashmap = "5.4.0"
-futures-util = "0.3.27"
+futures-util = "0.3.28"
 hostname = "0.3.1"
-libc = "0.2.140"
+libc = "0.2.144"
 once_cell = "1.17.1"
-phper = "0.11.0"
-prost = "0.11.8"
-serde_json = { version = "1.0.94", features = ["preserve_order"] }
-skywalking = { version = "0.6.0", features = ["management"] }
+phper = "0.12.0"
+prost = "0.11.9"
+serde_json = { version = "1.0.96", features = ["preserve_order"] }
+skywalking = { version = "0.7.0", features = ["management"] }
 systemstat = "0.2.3"
-thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = ["full"] }
-tokio-stream = "0.1.12"
+thiserror = "1.0.40"
+tokio = { version = "1.28.1", features = ["full"] }
+tokio-stream = "0.1.14"
 tonic = { version = "0.8.3", features = ["tls"] }
 tracing = { version = "0.1.37", features = ["attributes"] }
-tracing-subscriber = "0.3.16"
+tracing-subscriber = "0.3.17"
 url = "2.3.1"
 
 [dev-dependencies]
-axum = "0.6.11"
+axum = "0.6.18"
 fastcgi-client = "0.8.0"
-reqwest = { version = "0.11.14", features = ["trust-dns", "json", "stream"] }
+reqwest = { version = "0.11.18", features = ["trust-dns", "json", "stream"] }

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -198,7 +198,7 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
 The following components are provided under the (MIT OR Apache-2.0) AND Unicode-DFS-2016 License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/unicode-ident/1.0.6 1.0.6 (MIT OR Apache-2.0) AND Unicode-DFS-2016
+    https://crates.io/crates/unicode-ident/1.0.8 1.0.8 (MIT OR Apache-2.0) AND Unicode-DFS-2016
 
 ========================================================================
 0BSD OR Apache-2.0 OR MIT licenses
@@ -213,19 +213,19 @@ Apache-2.0 licenses
 ========================================================================
 The following components are provided under the Apache-2.0 License. See project link for details.
 The text of each license is the standard Apache 2.0 license.
-    https://crates.io/crates/bytesize/1.1.0 1.1.0 Apache-2.0
-    https://crates.io/crates/clang-sys/1.4.0 1.4.0 Apache-2.0
+    https://crates.io/crates/bytesize/1.2.0 1.2.0 Apache-2.0
+    https://crates.io/crates/clang-sys/1.6.1 1.6.1 Apache-2.0
     https://crates.io/crates/codespan-reporting/0.11.1 0.11.1 Apache-2.0
     https://crates.io/crates/fastcgi-client/0.8.0 0.8.0 Apache-2.0
     https://crates.io/crates/openssl/0.10.48 0.10.48 Apache-2.0
-    https://crates.io/crates/prost/0.11.8 0.11.8 Apache-2.0
-    https://crates.io/crates/prost-build/0.11.6 0.11.6 Apache-2.0
-    https://crates.io/crates/prost-derive/0.11.8 0.11.8 Apache-2.0
-    https://crates.io/crates/prost-types/0.11.6 0.11.6 Apache-2.0
+    https://crates.io/crates/prost/0.11.9 0.11.9 Apache-2.0
+    https://crates.io/crates/prost-build/0.11.9 0.11.9 Apache-2.0
+    https://crates.io/crates/prost-derive/0.11.9 0.11.9 Apache-2.0
+    https://crates.io/crates/prost-types/0.11.9 0.11.9 Apache-2.0
     https://crates.io/crates/scripts/0.0.0 0.0.0 Apache-2.0
-    https://crates.io/crates/skywalking/0.6.0 0.6.0 Apache-2.0
+    https://crates.io/crates/skywalking/0.7.0 0.7.0 Apache-2.0
     https://crates.io/crates/skywalking-php/0.6.0-dev 0.6.0-dev Apache-2.0
-    https://crates.io/crates/sync_wrapper/0.1.1 0.1.1 Apache-2.0
+    https://crates.io/crates/sync_wrapper/0.1.2 0.1.2 Apache-2.0
 
 ========================================================================
 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT licenses
@@ -233,10 +233,9 @@ Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT licenses
 The following components are provided under the Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/io-lifetimes/1.0.5 1.0.5 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-    https://crates.io/crates/linux-raw-sys/0.1.4 0.1.4 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-    https://crates.io/crates/rustix/0.36.8 0.36.8 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-    https://crates.io/crates/wasi/0.10.0+wasi-snapshot-preview1 0.10.0+wasi-snapshot-preview1 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+    https://crates.io/crates/io-lifetimes/1.0.10 1.0.10 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+    https://crates.io/crates/linux-raw-sys/0.3.8 0.3.8 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+    https://crates.io/crates/rustix/0.37.19 0.37.19 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
     https://crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1 0.11.0+wasi-snapshot-preview1 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
 
 ========================================================================
@@ -245,7 +244,7 @@ Apache-2.0 OR BSL-1.0 licenses
 The following components are provided under the Apache-2.0 OR BSL-1.0 License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/ryu/1.0.12 1.0.12 Apache-2.0 OR BSL-1.0
+    https://crates.io/crates/ryu/1.0.13 1.0.13 Apache-2.0 OR BSL-1.0
 
 ========================================================================
 Apache-2.0 OR ISC OR MIT licenses
@@ -265,8 +264,13 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://crates.io/crates/addr2line/0.19.0 0.19.0 Apache-2.0 OR MIT
     https://crates.io/crates/android_system_properties/0.1.5 0.1.5 Apache-2.0 OR MIT
-    https://crates.io/crates/anyhow/1.0.69 1.0.69 Apache-2.0 OR MIT
-    https://crates.io/crates/async-trait/0.1.61 0.1.61 Apache-2.0 OR MIT
+    https://crates.io/crates/anstream/0.3.2 0.3.2 Apache-2.0 OR MIT
+    https://crates.io/crates/anstyle/1.0.0 1.0.0 Apache-2.0 OR MIT
+    https://crates.io/crates/anstyle-parse/0.2.0 0.2.0 Apache-2.0 OR MIT
+    https://crates.io/crates/anstyle-query/1.0.0 1.0.0 Apache-2.0 OR MIT
+    https://crates.io/crates/anstyle-wincon/1.0.1 1.0.1 Apache-2.0 OR MIT
+    https://crates.io/crates/anyhow/1.0.71 1.0.71 Apache-2.0 OR MIT
+    https://crates.io/crates/async-trait/0.1.68 0.1.68 Apache-2.0 OR MIT
     https://crates.io/crates/autocfg/1.1.0 1.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/backtrace/0.3.67 0.3.67 Apache-2.0 OR MIT
     https://crates.io/crates/base64/0.13.1 0.13.1 Apache-2.0 OR MIT
@@ -281,11 +285,13 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/chrono/0.4.24 0.4.24 Apache-2.0 OR MIT
     https://crates.io/crates/chrono-tz/0.6.1 0.6.1 Apache-2.0 OR MIT
     https://crates.io/crates/chrono-tz-build/0.0.2 0.0.2 Apache-2.0 OR MIT
-    https://crates.io/crates/clap/4.1.8 4.1.8 Apache-2.0 OR MIT
-    https://crates.io/crates/clap_derive/4.1.8 4.1.8 Apache-2.0 OR MIT
-    https://crates.io/crates/clap_lex/0.3.0 0.3.0 Apache-2.0 OR MIT
+    https://crates.io/crates/clap/4.3.0 4.3.0 Apache-2.0 OR MIT
+    https://crates.io/crates/clap_builder/4.3.0 4.3.0 Apache-2.0 OR MIT
+    https://crates.io/crates/clap_derive/4.3.0 4.3.0 Apache-2.0 OR MIT
+    https://crates.io/crates/clap_lex/0.5.0 0.5.0 Apache-2.0 OR MIT
+    https://crates.io/crates/colorchoice/1.0.0 1.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/core-foundation/0.9.3 0.9.3 Apache-2.0 OR MIT
-    https://crates.io/crates/core-foundation-sys/0.8.3 0.8.3 Apache-2.0 OR MIT
+    https://crates.io/crates/core-foundation-sys/0.8.4 0.8.4 Apache-2.0 OR MIT
     https://crates.io/crates/cpufeatures/0.2.5 0.2.5 Apache-2.0 OR MIT
     https://crates.io/crates/crypto-common/0.1.6 0.1.6 Apache-2.0 OR MIT
     https://crates.io/crates/cxx/1.0.86 1.0.86 Apache-2.0 OR MIT
@@ -295,26 +301,27 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/digest/0.10.6 0.10.6 Apache-2.0 OR MIT
     https://crates.io/crates/either/1.8.1 1.8.1 Apache-2.0 OR MIT
     https://crates.io/crates/enum-as-inner/0.5.1 0.5.1 Apache-2.0 OR MIT
-    https://crates.io/crates/errno/0.2.8 0.2.8 Apache-2.0 OR MIT
-    https://crates.io/crates/fastrand/1.8.0 1.8.0 Apache-2.0 OR MIT
+    https://crates.io/crates/errno/0.3.1 0.3.1 Apache-2.0 OR MIT
+    https://crates.io/crates/fastrand/1.9.0 1.9.0 Apache-2.0 OR MIT
     https://crates.io/crates/fixedbitset/0.4.2 0.4.2 Apache-2.0 OR MIT
     https://crates.io/crates/fnv/1.0.7 1.0.7 Apache-2.0 OR MIT
     https://crates.io/crates/foreign-types/0.3.2 0.3.2 Apache-2.0 OR MIT
     https://crates.io/crates/foreign-types-shared/0.1.1 0.1.1 Apache-2.0 OR MIT
     https://crates.io/crates/form_urlencoded/1.1.0 1.1.0 Apache-2.0 OR MIT
-    https://crates.io/crates/futures-channel/0.3.25 0.3.25 Apache-2.0 OR MIT
-    https://crates.io/crates/futures-core/0.3.27 0.3.27 Apache-2.0 OR MIT
-    https://crates.io/crates/futures-io/0.3.27 0.3.27 Apache-2.0 OR MIT
-    https://crates.io/crates/futures-macro/0.3.27 0.3.27 Apache-2.0 OR MIT
-    https://crates.io/crates/futures-sink/0.3.27 0.3.27 Apache-2.0 OR MIT
-    https://crates.io/crates/futures-task/0.3.27 0.3.27 Apache-2.0 OR MIT
-    https://crates.io/crates/futures-util/0.3.27 0.3.27 Apache-2.0 OR MIT
-    https://crates.io/crates/getrandom/0.2.8 0.2.8 Apache-2.0 OR MIT
-    https://crates.io/crates/gimli/0.27.0 0.27.0 Apache-2.0 OR MIT
+    https://crates.io/crates/futures-channel/0.3.28 0.3.28 Apache-2.0 OR MIT
+    https://crates.io/crates/futures-core/0.3.28 0.3.28 Apache-2.0 OR MIT
+    https://crates.io/crates/futures-io/0.3.28 0.3.28 Apache-2.0 OR MIT
+    https://crates.io/crates/futures-macro/0.3.28 0.3.28 Apache-2.0 OR MIT
+    https://crates.io/crates/futures-sink/0.3.28 0.3.28 Apache-2.0 OR MIT
+    https://crates.io/crates/futures-task/0.3.28 0.3.28 Apache-2.0 OR MIT
+    https://crates.io/crates/futures-util/0.3.28 0.3.28 Apache-2.0 OR MIT
+    https://crates.io/crates/getrandom/0.2.9 0.2.9 Apache-2.0 OR MIT
+    https://crates.io/crates/gimli/0.27.2 0.27.2 Apache-2.0 OR MIT
     https://crates.io/crates/glob/0.3.1 0.3.1 Apache-2.0 OR MIT
     https://crates.io/crates/hashbrown/0.12.3 0.12.3 Apache-2.0 OR MIT
     https://crates.io/crates/heck/0.4.1 0.4.1 Apache-2.0 OR MIT
     https://crates.io/crates/hermit-abi/0.2.6 0.2.6 Apache-2.0 OR MIT
+    https://crates.io/crates/hermit-abi/0.3.1 0.3.1 Apache-2.0 OR MIT
     https://crates.io/crates/http/0.2.9 0.2.9 Apache-2.0 OR MIT
     https://crates.io/crates/httparse/1.8.0 1.8.0 Apache-2.0 OR MIT
     https://crates.io/crates/httpdate/1.0.2 1.0.2 Apache-2.0 OR MIT
@@ -325,15 +332,15 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/iana-time-zone-haiku/0.1.1 0.1.1 Apache-2.0 OR MIT
     https://crates.io/crates/idna/0.2.3 0.2.3 Apache-2.0 OR MIT
     https://crates.io/crates/idna/0.3.0 0.3.0 Apache-2.0 OR MIT
-    https://crates.io/crates/indexmap/1.9.2 1.9.2 Apache-2.0 OR MIT
+    https://crates.io/crates/indexmap/1.9.3 1.9.3 Apache-2.0 OR MIT
     https://crates.io/crates/ipconfig/0.3.1 0.3.1 Apache-2.0 OR MIT
     https://crates.io/crates/ipnet/2.7.1 2.7.1 Apache-2.0 OR MIT
     https://crates.io/crates/itertools/0.10.5 0.10.5 Apache-2.0 OR MIT
-    https://crates.io/crates/itoa/1.0.5 1.0.5 Apache-2.0 OR MIT
-    https://crates.io/crates/js-sys/0.3.60 0.3.60 Apache-2.0 OR MIT
+    https://crates.io/crates/itoa/1.0.6 1.0.6 Apache-2.0 OR MIT
+    https://crates.io/crates/js-sys/0.3.62 0.3.62 Apache-2.0 OR MIT
     https://crates.io/crates/lazy_static/1.4.0 1.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/lazycell/1.3.0 1.3.0 Apache-2.0 OR MIT
-    https://crates.io/crates/libc/0.2.140 0.2.140 Apache-2.0 OR MIT
+    https://crates.io/crates/libc/0.2.144 0.2.144 Apache-2.0 OR MIT
     https://crates.io/crates/libm/0.2.6 0.2.6 Apache-2.0 OR MIT
     https://crates.io/crates/link-cplusplus/1.0.8 1.0.8 Apache-2.0 OR MIT
     https://crates.io/crates/linked-hash-map/0.5.6 0.5.6 Apache-2.0 OR MIT
@@ -341,76 +348,74 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/log/0.4.17 0.4.17 Apache-2.0 OR MIT
     https://crates.io/crates/lru-cache/0.1.2 0.1.2 Apache-2.0 OR MIT
     https://crates.io/crates/match_cfg/0.1.0 0.1.0 Apache-2.0 OR MIT
-    https://crates.io/crates/mime/0.3.16 0.3.16 Apache-2.0 OR MIT
+    https://crates.io/crates/mime/0.3.17 0.3.17 Apache-2.0 OR MIT
     https://crates.io/crates/minimal-lexical/0.2.1 0.2.1 Apache-2.0 OR MIT
     https://crates.io/crates/multimap/0.8.3 0.8.3 Apache-2.0 OR MIT
     https://crates.io/crates/native-tls/0.2.11 0.2.11 Apache-2.0 OR MIT
     https://crates.io/crates/num-integer/0.1.45 0.1.45 Apache-2.0 OR MIT
     https://crates.io/crates/num-traits/0.2.15 0.2.15 Apache-2.0 OR MIT
     https://crates.io/crates/num_cpus/1.15.0 1.15.0 Apache-2.0 OR MIT
-    https://crates.io/crates/object/0.30.1 0.30.1 Apache-2.0 OR MIT
+    https://crates.io/crates/object/0.30.3 0.30.3 Apache-2.0 OR MIT
     https://crates.io/crates/once_cell/1.17.1 1.17.1 Apache-2.0 OR MIT
     https://crates.io/crates/openssl-macros/0.1.0 0.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/openssl-probe/0.1.5 0.1.5 Apache-2.0 OR MIT
-    https://crates.io/crates/os_str_bytes/6.4.1 6.4.1 Apache-2.0 OR MIT
     https://crates.io/crates/parking_lot/0.12.1 0.12.1 Apache-2.0 OR MIT
-    https://crates.io/crates/parking_lot_core/0.9.5 0.9.5 Apache-2.0 OR MIT
+    https://crates.io/crates/parking_lot_core/0.9.7 0.9.7 Apache-2.0 OR MIT
     https://crates.io/crates/peeking_take_while/0.1.2 0.1.2 Apache-2.0 OR MIT
     https://crates.io/crates/percent-encoding/2.2.0 2.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/pest/2.5.6 2.5.6 Apache-2.0 OR MIT
     https://crates.io/crates/pest_derive/2.5.6 2.5.6 Apache-2.0 OR MIT
     https://crates.io/crates/pest_generator/2.5.6 2.5.6 Apache-2.0 OR MIT
     https://crates.io/crates/pest_meta/2.5.6 2.5.6 Apache-2.0 OR MIT
-    https://crates.io/crates/petgraph/0.6.2 0.6.2 Apache-2.0 OR MIT
-    https://crates.io/crates/pin-project/1.0.12 1.0.12 Apache-2.0 OR MIT
-    https://crates.io/crates/pin-project-internal/1.0.12 1.0.12 Apache-2.0 OR MIT
+    https://crates.io/crates/petgraph/0.6.3 0.6.3 Apache-2.0 OR MIT
+    https://crates.io/crates/pin-project/1.1.0 1.1.0 Apache-2.0 OR MIT
+    https://crates.io/crates/pin-project-internal/1.1.0 1.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/pin-project-lite/0.2.9 0.2.9 Apache-2.0 OR MIT
     https://crates.io/crates/pin-utils/0.1.0 0.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/pkg-config/0.3.26 0.3.26 Apache-2.0 OR MIT
-    https://crates.io/crates/portable-atomic/0.3.19 0.3.19 Apache-2.0 OR MIT
+    https://crates.io/crates/portable-atomic/0.3.20 0.3.20 Apache-2.0 OR MIT
+    https://crates.io/crates/portable-atomic/1.3.2 1.3.2 Apache-2.0 OR MIT
     https://crates.io/crates/ppv-lite86/0.2.17 0.2.17 Apache-2.0 OR MIT
-    https://crates.io/crates/prettyplease/0.1.23 0.1.23 Apache-2.0 OR MIT
-    https://crates.io/crates/proc-macro-error/1.0.4 1.0.4 Apache-2.0 OR MIT
-    https://crates.io/crates/proc-macro-error-attr/1.0.4 1.0.4 Apache-2.0 OR MIT
-    https://crates.io/crates/proc-macro2/1.0.51 1.0.51 Apache-2.0 OR MIT
+    https://crates.io/crates/prettyplease/0.1.25 0.1.25 Apache-2.0 OR MIT
+    https://crates.io/crates/proc-macro2/1.0.59 1.0.59 Apache-2.0 OR MIT
     https://crates.io/crates/quick-error/1.2.3 1.2.3 Apache-2.0 OR MIT
-    https://crates.io/crates/quote/1.0.23 1.0.23 Apache-2.0 OR MIT
+    https://crates.io/crates/quote/1.0.28 1.0.28 Apache-2.0 OR MIT
     https://crates.io/crates/rand/0.8.5 0.8.5 Apache-2.0 OR MIT
     https://crates.io/crates/rand_chacha/0.3.1 0.3.1 Apache-2.0 OR MIT
     https://crates.io/crates/rand_core/0.6.4 0.6.4 Apache-2.0 OR MIT
-    https://crates.io/crates/regex/1.7.1 1.7.1 Apache-2.0 OR MIT
-    https://crates.io/crates/regex-syntax/0.6.28 0.6.28 Apache-2.0 OR MIT
-    https://crates.io/crates/reqwest/0.11.14 0.11.14 Apache-2.0 OR MIT
+    https://crates.io/crates/regex/1.8.1 1.8.1 Apache-2.0 OR MIT
+    https://crates.io/crates/regex-syntax/0.7.1 0.7.1 Apache-2.0 OR MIT
+    https://crates.io/crates/reqwest/0.11.18 0.11.18 Apache-2.0 OR MIT
     https://crates.io/crates/resolv-conf/0.7.0 0.7.0 Apache-2.0 OR MIT
-    https://crates.io/crates/rustc-demangle/0.1.21 0.1.21 Apache-2.0 OR MIT
+    https://crates.io/crates/rustc-demangle/0.1.23 0.1.23 Apache-2.0 OR MIT
     https://crates.io/crates/rustc-hash/1.1.0 1.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/rustc_version/0.4.0 0.4.0 Apache-2.0 OR MIT
-    https://crates.io/crates/rustversion/1.0.11 1.0.11 Apache-2.0 OR MIT
+    https://crates.io/crates/rustversion/1.0.12 1.0.12 Apache-2.0 OR MIT
     https://crates.io/crates/scopeguard/1.1.0 1.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/scratch/1.0.3 1.0.3 Apache-2.0 OR MIT
     https://crates.io/crates/security-framework/2.7.0 2.7.0 Apache-2.0 OR MIT
-    https://crates.io/crates/security-framework-sys/2.6.1 2.6.1 Apache-2.0 OR MIT
-    https://crates.io/crates/semver/1.0.16 1.0.16 Apache-2.0 OR MIT
-    https://crates.io/crates/serde/1.0.155 1.0.155 Apache-2.0 OR MIT
-    https://crates.io/crates/serde_derive/1.0.155 1.0.155 Apache-2.0 OR MIT
-    https://crates.io/crates/serde_json/1.0.94 1.0.94 Apache-2.0 OR MIT
-    https://crates.io/crates/serde_path_to_error/0.1.9 0.1.9 Apache-2.0 OR MIT
+    https://crates.io/crates/security-framework-sys/2.8.0 2.8.0 Apache-2.0 OR MIT
+    https://crates.io/crates/semver/1.0.17 1.0.17 Apache-2.0 OR MIT
+    https://crates.io/crates/serde/1.0.163 1.0.163 Apache-2.0 OR MIT
+    https://crates.io/crates/serde_derive/1.0.163 1.0.163 Apache-2.0 OR MIT
+    https://crates.io/crates/serde_json/1.0.96 1.0.96 Apache-2.0 OR MIT
+    https://crates.io/crates/serde_path_to_error/0.1.11 0.1.11 Apache-2.0 OR MIT
     https://crates.io/crates/serde_urlencoded/0.7.1 0.7.1 Apache-2.0 OR MIT
     https://crates.io/crates/sha2/0.10.6 0.10.6 Apache-2.0 OR MIT
     https://crates.io/crates/shlex/1.1.0 1.1.0 Apache-2.0 OR MIT
-    https://crates.io/crates/signal-hook-registry/1.4.0 1.4.0 Apache-2.0 OR MIT
+    https://crates.io/crates/signal-hook-registry/1.4.1 1.4.1 Apache-2.0 OR MIT
     https://crates.io/crates/siphasher/0.3.10 0.3.10 Apache-2.0 OR MIT
     https://crates.io/crates/slug/0.1.4 0.1.4 Apache-2.0 OR MIT
     https://crates.io/crates/smallvec/1.10.0 1.10.0 Apache-2.0 OR MIT
-    https://crates.io/crates/socket2/0.4.7 0.4.7 Apache-2.0 OR MIT
+    https://crates.io/crates/socket2/0.4.9 0.4.9 Apache-2.0 OR MIT
     https://crates.io/crates/syn/1.0.109 1.0.109 Apache-2.0 OR MIT
-    https://crates.io/crates/tempfile/3.4.0 3.4.0 Apache-2.0 OR MIT
-    https://crates.io/crates/thiserror/1.0.39 1.0.39 Apache-2.0 OR MIT
-    https://crates.io/crates/thiserror-impl/1.0.39 1.0.39 Apache-2.0 OR MIT
+    https://crates.io/crates/syn/2.0.18 2.0.18 Apache-2.0 OR MIT
+    https://crates.io/crates/tempfile/3.5.0 3.5.0 Apache-2.0 OR MIT
+    https://crates.io/crates/thiserror/1.0.40 1.0.40 Apache-2.0 OR MIT
+    https://crates.io/crates/thiserror-impl/1.0.40 1.0.40 Apache-2.0 OR MIT
     https://crates.io/crates/thread_local/1.1.4 1.1.4 Apache-2.0 OR MIT
-    https://crates.io/crates/time/0.1.45 0.1.45 Apache-2.0 OR MIT
-    https://crates.io/crates/time/0.3.17 0.3.17 Apache-2.0 OR MIT
-    https://crates.io/crates/time-core/0.1.0 0.1.0 Apache-2.0 OR MIT
+    https://crates.io/crates/time/0.3.21 0.3.21 Apache-2.0 OR MIT
+    https://crates.io/crates/time-core/0.1.1 0.1.1 Apache-2.0 OR MIT
     https://crates.io/crates/tokio-io-timeout/1.2.0 1.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/tokio-rustls/0.23.4 0.23.4 Apache-2.0 OR MIT
     https://crates.io/crates/trust-dns-proto/0.22.0 0.22.0 Apache-2.0 OR MIT
@@ -428,15 +433,16 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/unicode-normalization/0.1.22 0.1.22 Apache-2.0 OR MIT
     https://crates.io/crates/unicode-width/0.1.10 0.1.10 Apache-2.0 OR MIT
     https://crates.io/crates/url/2.3.1 2.3.1 Apache-2.0 OR MIT
-    https://crates.io/crates/uuid/1.2.2 1.2.2 Apache-2.0 OR MIT
+    https://crates.io/crates/utf8parse/0.2.1 0.2.1 Apache-2.0 OR MIT
+    https://crates.io/crates/uuid/1.3.3 1.3.3 Apache-2.0 OR MIT
     https://crates.io/crates/vcpkg/0.2.15 0.2.15 Apache-2.0 OR MIT
     https://crates.io/crates/version_check/0.9.4 0.9.4 Apache-2.0 OR MIT
-    https://crates.io/crates/wasm-bindgen/0.2.83 0.2.83 Apache-2.0 OR MIT
-    https://crates.io/crates/wasm-bindgen-backend/0.2.83 0.2.83 Apache-2.0 OR MIT
-    https://crates.io/crates/wasm-bindgen-futures/0.4.33 0.4.33 Apache-2.0 OR MIT
-    https://crates.io/crates/wasm-bindgen-macro/0.2.83 0.2.83 Apache-2.0 OR MIT
-    https://crates.io/crates/wasm-bindgen-macro-support/0.2.83 0.2.83 Apache-2.0 OR MIT
-    https://crates.io/crates/wasm-bindgen-shared/0.2.83 0.2.83 Apache-2.0 OR MIT
+    https://crates.io/crates/wasm-bindgen/0.2.85 0.2.85 Apache-2.0 OR MIT
+    https://crates.io/crates/wasm-bindgen-backend/0.2.85 0.2.85 Apache-2.0 OR MIT
+    https://crates.io/crates/wasm-bindgen-futures/0.4.35 0.4.35 Apache-2.0 OR MIT
+    https://crates.io/crates/wasm-bindgen-macro/0.2.85 0.2.85 Apache-2.0 OR MIT
+    https://crates.io/crates/wasm-bindgen-macro-support/0.2.85 0.2.85 Apache-2.0 OR MIT
+    https://crates.io/crates/wasm-bindgen-shared/0.2.85 0.2.85 Apache-2.0 OR MIT
     https://crates.io/crates/wasm-streams/0.2.3 0.2.3 Apache-2.0 OR MIT
     https://crates.io/crates/web-sys/0.3.60 0.3.60 Apache-2.0 OR MIT
     https://crates.io/crates/widestring/0.5.1 0.5.1 Apache-2.0 OR MIT
@@ -445,14 +451,23 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0 0.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/windows-sys/0.42.0 0.42.0 Apache-2.0 OR MIT
     https://crates.io/crates/windows-sys/0.45.0 0.45.0 Apache-2.0 OR MIT
-    https://crates.io/crates/windows-targets/0.42.1 0.42.1 Apache-2.0 OR MIT
-    https://crates.io/crates/windows_aarch64_gnullvm/0.42.1 0.42.1 Apache-2.0 OR MIT
-    https://crates.io/crates/windows_aarch64_msvc/0.42.1 0.42.1 Apache-2.0 OR MIT
-    https://crates.io/crates/windows_i686_gnu/0.42.1 0.42.1 Apache-2.0 OR MIT
-    https://crates.io/crates/windows_i686_msvc/0.42.1 0.42.1 Apache-2.0 OR MIT
-    https://crates.io/crates/windows_x86_64_gnu/0.42.1 0.42.1 Apache-2.0 OR MIT
-    https://crates.io/crates/windows_x86_64_gnullvm/0.42.1 0.42.1 Apache-2.0 OR MIT
-    https://crates.io/crates/windows_x86_64_msvc/0.42.1 0.42.1 Apache-2.0 OR MIT
+    https://crates.io/crates/windows-sys/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows-targets/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows-targets/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_aarch64_gnullvm/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_aarch64_gnullvm/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_aarch64_msvc/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_aarch64_msvc/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_i686_gnu/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_i686_gnu/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_i686_msvc/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_i686_msvc/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_x86_64_gnu/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_x86_64_gnu/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_x86_64_gnullvm/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_x86_64_gnullvm/0.48.0 0.48.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_x86_64_msvc/0.42.2 0.42.2 Apache-2.0 OR MIT
+    https://crates.io/crates/windows_x86_64_msvc/0.48.0 0.48.0 Apache-2.0 OR MIT
 
 ========================================================================
 Apache-2.0 OR MIT OR Zlib licenses
@@ -498,12 +513,12 @@ MIT licenses
 The following components are provided under the MIT License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/async-stream/0.3.3 0.3.3 MIT
-    https://crates.io/crates/async-stream-impl/0.3.3 0.3.3 MIT
-    https://crates.io/crates/axum/0.6.11 0.6.11 MIT
-    https://crates.io/crates/axum-core/0.3.3 0.3.3 MIT
+    https://crates.io/crates/async-stream/0.3.5 0.3.5 MIT
+    https://crates.io/crates/async-stream-impl/0.3.5 0.3.5 MIT
+    https://crates.io/crates/axum/0.6.18 0.6.18 MIT
+    https://crates.io/crates/axum-core/0.3.4 0.3.4 MIT
     https://crates.io/crates/bincode/1.3.3 1.3.3 MIT
-    https://crates.io/crates/bytes/1.3.0 1.3.0 MIT
+    https://crates.io/crates/bytes/1.4.0 1.4.0 MIT
     https://crates.io/crates/convert_case/0.4.0 0.4.0 MIT
     https://crates.io/crates/dashmap/5.4.0 5.4.0 MIT
     https://crates.io/crates/data-encoding/2.3.3 2.3.3 MIT
@@ -511,15 +526,15 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/errno-dragonfly/0.1.2 0.1.2 MIT
     https://crates.io/crates/generic-array/0.14.6 0.14.6 MIT
     https://crates.io/crates/globwalk/0.8.1 0.8.1 MIT
-    https://crates.io/crates/h2/0.3.17 0.3.17 MIT
+    https://crates.io/crates/h2/0.3.19 0.3.19 MIT
     https://crates.io/crates/hostname/0.3.1 0.3.1 MIT
     https://crates.io/crates/http-body/0.4.5 0.4.5 MIT
-    https://crates.io/crates/hyper/0.14.25 0.14.25 MIT
-    https://crates.io/crates/is-terminal/0.4.2 0.4.2 MIT
+    https://crates.io/crates/hyper/0.14.26 0.14.26 MIT
+    https://crates.io/crates/is-terminal/0.4.7 0.4.7 MIT
     https://crates.io/crates/matches/0.1.9 0.1.9 MIT
     https://crates.io/crates/matchit/0.7.0 0.7.0 MIT
-    https://crates.io/crates/mio/0.8.5 0.8.5 MIT
-    https://crates.io/crates/nom/7.1.2 7.1.2 MIT
+    https://crates.io/crates/mio/0.8.6 0.8.6 MIT
+    https://crates.io/crates/nom/7.1.3 7.1.3 MIT
     https://crates.io/crates/nu-ansi-term/0.46.0 0.46.0 MIT
     https://crates.io/crates/openssl-sys/0.9.83 0.9.83 MIT
     https://crates.io/crates/overload/0.1.1 0.1.1 MIT
@@ -529,28 +544,29 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/phf_generator/0.10.0 0.10.0 MIT
     https://crates.io/crates/phf_shared/0.10.0 0.10.0 MIT
     https://crates.io/crates/redox_syscall/0.2.16 0.2.16 MIT
+    https://crates.io/crates/redox_syscall/0.3.5 0.3.5 MIT
     https://crates.io/crates/schannel/0.1.21 0.1.21 MIT
     https://crates.io/crates/sharded-slab/0.1.4 0.1.4 MIT
-    https://crates.io/crates/slab/0.4.7 0.4.7 MIT
+    https://crates.io/crates/slab/0.4.8 0.4.8 MIT
     https://crates.io/crates/spin/0.5.2 0.5.2 MIT
     https://crates.io/crates/strsim/0.10.0 0.10.0 MIT
-    https://crates.io/crates/tera/1.18.0 1.18.0 MIT
-    https://crates.io/crates/tokio/1.26.0 1.26.0 MIT
-    https://crates.io/crates/tokio-macros/1.8.2 1.8.2 MIT
+    https://crates.io/crates/tera/1.18.1 1.18.1 MIT
+    https://crates.io/crates/tokio/1.28.1 1.28.1 MIT
+    https://crates.io/crates/tokio-macros/2.1.0 2.1.0 MIT
     https://crates.io/crates/tokio-native-tls/0.3.0 0.3.0 MIT
-    https://crates.io/crates/tokio-stream/0.1.12 0.1.12 MIT
-    https://crates.io/crates/tokio-util/0.7.4 0.7.4 MIT
+    https://crates.io/crates/tokio-stream/0.1.14 0.1.14 MIT
+    https://crates.io/crates/tokio-util/0.7.8 0.7.8 MIT
     https://crates.io/crates/tonic/0.8.3 0.8.3 MIT
     https://crates.io/crates/tonic-build/0.8.4 0.8.4 MIT
     https://crates.io/crates/tower/0.4.13 0.4.13 MIT
     https://crates.io/crates/tower-layer/0.3.2 0.3.2 MIT
     https://crates.io/crates/tower-service/0.3.2 0.3.2 MIT
     https://crates.io/crates/tracing/0.1.37 0.1.37 MIT
-    https://crates.io/crates/tracing-attributes/0.1.23 0.1.23 MIT
-    https://crates.io/crates/tracing-core/0.1.30 0.1.30 MIT
+    https://crates.io/crates/tracing-attributes/0.1.24 0.1.24 MIT
+    https://crates.io/crates/tracing-core/0.1.31 0.1.31 MIT
     https://crates.io/crates/tracing-futures/0.2.5 0.2.5 MIT
     https://crates.io/crates/tracing-log/0.1.3 0.1.3 MIT
-    https://crates.io/crates/tracing-subscriber/0.3.16 0.3.16 MIT
+    https://crates.io/crates/tracing-subscriber/0.3.17 0.3.17 MIT
     https://crates.io/crates/try-lock/0.2.4 0.2.4 MIT
     https://crates.io/crates/valuable/0.1.0 0.1.0 MIT
     https://crates.io/crates/want/0.3.0 0.3.0 MIT
@@ -564,6 +580,7 @@ The following components are provided under the MIT OR Unlicense License. See pr
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://crates.io/crates/aho-corasick/0.7.20 0.7.20 MIT OR Unlicense
+    https://crates.io/crates/aho-corasick/1.0.1 1.0.1 MIT OR Unlicense
     https://crates.io/crates/globset/0.4.10 0.4.10 MIT OR Unlicense
     https://crates.io/crates/ignore/0.4.19 0.4.19 MIT OR Unlicense
     https://crates.io/crates/memchr/2.5.0 2.5.0 MIT OR Unlicense
@@ -578,11 +595,11 @@ MulanPSL-2.0 licenses
 The following components are provided under the MulanPSL-2.0 License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/phper/0.11.1 0.11.1 MulanPSL-2.0
-    https://crates.io/crates/phper-alloc/0.11.1 0.11.1 MulanPSL-2.0
-    https://crates.io/crates/phper-build/0.11.1 0.11.1 MulanPSL-2.0
-    https://crates.io/crates/phper-macros/0.11.1 0.11.1 MulanPSL-2.0
-    https://crates.io/crates/phper-sys/0.11.1 0.11.1 MulanPSL-2.0
+    https://crates.io/crates/phper/0.12.0 0.12.0 MulanPSL-2.0
+    https://crates.io/crates/phper-alloc/0.12.0 0.12.0 MulanPSL-2.0
+    https://crates.io/crates/phper-build/0.12.0 0.12.0 MulanPSL-2.0
+    https://crates.io/crates/phper-macros/0.12.0 0.12.0 MulanPSL-2.0
+    https://crates.io/crates/phper-sys/0.12.0 0.12.0 MulanPSL-2.0
 
 ========================================================================
 Unlicense licenses

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -25,10 +25,10 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-anyhow = "1.0.69"
-chrono = "0.4.24"
-clap = { version = "4.1.8", features = ["derive"] }
-serde = { version = "1.0.155", features = ["derive"] }
-tera = "1.18.0"
+anyhow = "1.0.71"
+chrono = { version = "0.4.24", default-features = false, features = ["std"] }
+clap = { version = "4.3.0", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
+tera = "1.18.1"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = "0.3.17"

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,7 +17,9 @@ use anyhow::anyhow;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use skywalking::trace::{
-    propagation::encoder::encode_propagation, span::Span, trace_context::TracingContext,
+    propagation::encoder::encode_propagation,
+    span::{AbstractSpan, Span},
+    trace_context::TracingContext,
 };
 
 pub const SW_HEADER: &str = "sw8";

--- a/src/module.rs
+++ b/src/module.rs
@@ -191,7 +191,7 @@ pub fn shutdown() {
         return;
     }
 
-    info!("Shutdowning skywalking agent");
+    debug!("skywalking agent shutdown hook called");
 }
 
 fn try_init_logger() -> anyhow::Result<()> {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -25,7 +25,7 @@ mod plugin_swoole;
 use crate::execute::{AfterExecuteHook, BeforeExecuteHook};
 use once_cell::sync::Lazy;
 use phper::{eg, objects::ZObj};
-use skywalking::trace::span::Span;
+use skywalking::trace::span::AbstractSpan;
 
 // Register plugins here.
 static PLUGINS: Lazy<Vec<Box<DynPlugin>>> = Lazy::new(|| {
@@ -77,7 +77,7 @@ pub fn select_plugin(class_name: Option<&str>, function_name: &str) -> Option<&'
     selected_plugin.map(AsRef::as_ref)
 }
 
-fn log_exception(span: &mut Span) {
+fn log_exception(span: &mut impl AbstractSpan) {
     let ex = unsafe { ZObj::try_from_mut_ptr(eg!(exception)) };
     if let Some(ex) = ex {
         let mut span_object = span.span_object_mut();

--- a/src/plugin/plugin_amqplib.rs
+++ b/src/plugin/plugin_amqplib.rs
@@ -28,7 +28,10 @@ use phper::{
     objects::{ZObj, ZObject},
     values::{ExecuteData, ZVal},
 };
-use skywalking::{skywalking_proto::v3::SpanLayer, trace::span::Span};
+use skywalking::{
+    proto::v3::SpanLayer,
+    trace::span::{AbstractSpan, Span},
+};
 
 #[derive(Default, Clone)]
 pub struct AmqplibPlugin;

--- a/src/plugin/plugin_amqplib.rs
+++ b/src/plugin/plugin_amqplib.rs
@@ -104,7 +104,7 @@ impl AmqplibPlugin {
             }),
             Box::new(move |_, span, _, _| {
                 let mut span = span.downcast::<Span>().unwrap();
-                log_exception(&mut span);
+                log_exception(&mut *span);
                 Ok(())
             }),
         )
@@ -137,7 +137,6 @@ impl AmqplibPlugin {
         span_object.add_tag(TAG_MQ_BROKER, peer);
         span_object.add_tag(TAG_MQ_TOPIC, exchange);
         span_object.add_tag(TAG_MQ_QUEUE, routing_key);
-        drop(span_object);
 
         Ok(span)
     }

--- a/src/plugin/plugin_memcached.rs
+++ b/src/plugin/plugin_memcached.rs
@@ -335,7 +335,7 @@ fn after_hook(
         }
     }
 
-    log_exception(&mut span);
+    log_exception(&mut *span);
 
     Ok(())
 }
@@ -361,7 +361,6 @@ fn create_exit_span<'a>(
         if let Some(key) = key {
             span_object.add_tag(TAG_CACHE_KEY, key)
         }
-        drop(span_object);
 
         Ok(span)
     })

--- a/src/plugin/plugin_memcached.rs
+++ b/src/plugin/plugin_memcached.rs
@@ -28,7 +28,10 @@ use phper::{
     objects::ZObj,
     values::{ExecuteData, ZVal},
 };
-use skywalking::{skywalking_proto::v3::SpanLayer, trace::span::Span};
+use skywalking::{
+    proto::v3::SpanLayer,
+    trace::span::{AbstractSpan, Span},
+};
 use tracing::{debug, instrument, warn};
 
 /// The method parameters is empty.

--- a/src/plugin/plugin_mysqli.rs
+++ b/src/plugin/plugin_mysqli.rs
@@ -23,7 +23,10 @@ use anyhow::Context;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use phper::{objects::ZObj, sys};
-use skywalking::{skywalking_proto::v3::SpanLayer, trace::span::Span};
+use skywalking::{
+    proto::v3::SpanLayer,
+    trace::span::{AbstractSpan, Span},
+};
 use tracing::debug;
 
 static MYSQL_MAP: Lazy<DashMap<u32, MySQLInfo>> = Lazy::new(Default::default);

--- a/src/plugin/plugin_mysqli.rs
+++ b/src/plugin/plugin_mysqli.rs
@@ -100,7 +100,7 @@ impl MySQLImprovedPlugin {
             }),
             Box::new(move |_, span, _, _| {
                 let mut span = span.downcast::<Span>().unwrap();
-                log_exception(&mut span);
+                log_exception(&mut *span);
                 Ok(())
             }),
         )
@@ -131,7 +131,7 @@ impl MySQLImprovedPlugin {
             }),
             Box::new(move |_, span, _, _| {
                 let mut span = span.downcast::<Span>().unwrap();
-                log_exception(&mut span);
+                log_exception(&mut *span);
                 Ok(())
             }),
         )
@@ -151,7 +151,6 @@ fn create_mysqli_exit_span(
         span_object.set_span_layer(SpanLayer::Database);
         span_object.component_id = COMPONENT_PHP_MYSQLI_ID;
         span_object.add_tag("db.type", "mysql");
-        drop(span_object);
 
         Ok(span)
     })

--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -108,7 +108,7 @@ impl PdoPlugin {
             }),
             Box::new(move |_, span, _, _| {
                 let mut span = span.downcast::<Span>().unwrap();
-                log_exception(&mut span);
+                log_exception(&mut *span);
                 Ok(())
             }),
         )
@@ -217,7 +217,7 @@ fn after_hook(
         }
     }
 
-    log_exception(&mut span);
+    log_exception(&mut *span);
 
     Ok(())
 }
@@ -275,7 +275,6 @@ fn create_exit_span_with_dsn(
         span_object.component_id = COMPONENT_PHP_PDO_ID;
         span_object.add_tag(TAG_DB_TYPE, &dsn.db_type);
         span_object.add_tag("db.data_source", &dsn.data_source);
-        drop(span_object);
 
         Ok(span)
     })

--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -29,7 +29,10 @@ use phper::{
     sys,
     values::{ExecuteData, ZVal},
 };
-use skywalking::{skywalking_proto::v3::SpanLayer, trace::span::Span};
+use skywalking::{
+    proto::v3::SpanLayer,
+    trace::span::{AbstractSpan, Span},
+};
 use std::{any::Any, str::FromStr};
 use tracing::{debug, warn};
 

--- a/src/plugin/plugin_predis.rs
+++ b/src/plugin/plugin_predis.rs
@@ -22,7 +22,10 @@ use crate::{
 };
 use once_cell::sync::Lazy;
 use phper::{eg, functions::call, values::ZVal};
-use skywalking::{skywalking_proto::v3::SpanLayer, trace::span::Span};
+use skywalking::{
+    proto::v3::SpanLayer,
+    trace::span::{AbstractSpan, Span},
+};
 use std::collections::HashSet;
 use tracing::debug;
 

--- a/src/plugin/plugin_predis.rs
+++ b/src/plugin/plugin_predis.rs
@@ -226,7 +226,6 @@ impl PredisPlugin {
                 if let Some(key) = key {
                     span_object.add_tag(TAG_CACHE_KEY, key)
                 }
-                drop(span_object);
 
                 Ok(Box::new(span))
             }),
@@ -242,7 +241,7 @@ impl PredisPlugin {
                     span.span_object_mut().is_error = true;
                 }
 
-                log_exception(&mut span);
+                log_exception(&mut *span);
 
                 Ok(())
             }),

--- a/src/plugin/plugin_redis.rs
+++ b/src/plugin/plugin_redis.rs
@@ -266,7 +266,6 @@ impl RedisPlugin {
                 span_object.set_span_layer(SpanLayer::Cache);
                 span_object.component_id = COMPONENT_PHP_REDIS_ID;
                 span_object.add_tag(TAG_CACHE_TYPE, "redis");
-                drop(span_object);
 
                 Ok(Box::new(span))
             }),
@@ -322,7 +321,6 @@ impl RedisPlugin {
                 if let Some(key) = key {
                     span_object.add_tag(TAG_CACHE_KEY, key)
                 }
-                drop(span_object);
 
                 Ok(Box::new(span))
             }),
@@ -362,7 +360,7 @@ fn after_hook(
 ) -> crate::Result<()> {
     let mut span = span.downcast::<Span>().unwrap();
 
-    log_exception(&mut span);
+    log_exception(&mut *span);
 
     Ok(())
 }

--- a/src/plugin/plugin_redis.rs
+++ b/src/plugin/plugin_redis.rs
@@ -29,7 +29,10 @@ use phper::{
     sys,
     values::{ExecuteData, ZVal},
 };
-use skywalking::{skywalking_proto::v3::SpanLayer, trace::span::Span};
+use skywalking::{
+    proto::v3::SpanLayer,
+    trace::span::{AbstractSpan, Span},
+};
 use std::{any::Any, collections::HashMap};
 use tracing::{debug, warn};
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -304,7 +304,6 @@ fn create_request_context(
     span_object.component_id = COMPONENT_PHP_ID;
     span_object.add_tag("url", url.to_string());
     span_object.add_tag("http.method", method);
-    drop(span_object);
 
     RequestContext::set_global(
         request_id,

--- a/src/request.rs
+++ b/src/request.rs
@@ -23,7 +23,7 @@ use anyhow::{anyhow, Context};
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use phper::{arrays::ZArr, eg, pg, sg, sys, values::ZVal};
-use skywalking::trace::{propagation::decoder::decode_propagation, tracer};
+use skywalking::trace::{propagation::decoder::decode_propagation, span::AbstractSpan, tracer};
 use std::{
     panic::AssertUnwindSafe,
     ptr::null_mut,

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -287,7 +287,7 @@ segmentItems:
                   parentEndpoint: "GET:/curl-multi.enter.php",
                   networkAddress: "",
                   refType: CrossProcess,
-                  parentSpanId: 3,
+                  parentSpanId: 1,
                   parentTraceSegmentId: "not null",
                   parentServiceInstance: "not null",
                   parentService: skywalking-agent-test-1,
@@ -318,7 +318,7 @@ segmentItems:
                   parentEndpoint: "GET:/curl-multi.enter.php",
                   networkAddress: "",
                   refType: CrossProcess,
-                  parentSpanId: 1,
+                  parentSpanId: 3,
                   parentTraceSegmentId: "not null",
                   parentServiceInstance: "not null",
                   parentService: skywalking-agent-test-1,
@@ -359,7 +359,7 @@ segmentItems:
         spans:
           - operationName: /not-exists.php
             parentSpanId: 0
-            spanId: 3
+            spanId: 1
             spanLayer: Http
             startTime: gt 0
             endTime: gt 0
@@ -393,7 +393,7 @@ segmentItems:
               - { key: status_code, value: "200" }
           - operationName: /curl.test.php
             parentSpanId: 0
-            spanId: 1
+            spanId: 3
             spanLayer: Http
             startTime: gt 0
             endTime: gt 0


### PR DESCRIPTION
1. As `skywalking-rust` released, switch to use `AsyncSpan` api in hooking `curl_multi_exec`.
2. Disable `chrono` default features to fix <https://github.com/apache/skywalking-php/security/dependabot/10>.
3. Other dependencies have no break changes.