### PR TITLE
Optionally enable zend observer api for auto instrumentation.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,6 +206,8 @@ jobs:
           toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
           command: test
           args: --release --workspace
+        env:
+          ENABLE_ZEND_OBSERVER: ${{ matrix.enable_zend_observer }}
 
       - name: View logs
         if: always()

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,7 +180,7 @@ jobs:
           command: test
           args: --release --workspace
         env:
-          ENABLE_ZEND_OBSERVER: ${{ matrix.enable_zend_observer }}
+          ENABLE_ZEND_OBSERVER: ${{ matrix.version.enable_zend_observer }}
         continue-on-error: true
 
       # Rebuild the mixture when cargo test failed.
@@ -207,7 +207,7 @@ jobs:
           command: test
           args: --release --workspace
         env:
-          ENABLE_ZEND_OBSERVER: ${{ matrix.enable_zend_observer }}
+          ENABLE_ZEND_OBSERVER: ${{ matrix.version.enable_zend_observer }}
 
       - name: View logs
         if: always()

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,16 +56,31 @@ jobs:
           # Many composer dependencies need PHP 7.2+
           - php: "7.2"
             swoole: "4.6.7"
+            enable_zend_observer: "Off"
           - php: "7.3"
             swoole: "4.7.1"
+            enable_zend_observer: "Off"
           - php: "7.4"
             swoole: "4.8.10"
+            enable_zend_observer: "Off"
           - php: "8.0"
             swoole: "5.0.0"
+            enable_zend_observer: "Off"
+          - php: "8.0"
+            swoole: "5.0.0"
+            enable_zend_observer: "On"
           - php: "8.1"
             swoole: "5.0.0"
+            enable_zend_observer: "Off"
+          - php: "8.1"
+            swoole: "5.0.0"
+            enable_zend_observer: "On"
           - php: "8.2"
             swoole: "5.0.0"
+            enable_zend_observer: "Off"
+          - php: "8.2"
+            swoole: "5.0.0"
+            enable_zend_observer: "On"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -164,6 +179,8 @@ jobs:
           toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
           command: test
           args: --release --workspace
+        env:
+          ENABLE_ZEND_OBSERVER: ${{ matrix.enable_zend_observer }}
         continue-on-error: true
 
       # Rebuild the mixture when cargo test failed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "phper-sys"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2538b854618f97f39c0612a9ad97c5980b8d6f32d3a01a9de605851dcaf9507"
+checksum = "fda67a4b0389183e564f08797db31b635eff8bb2b30cfe5cc2394acaa35cd6a7"
 dependencies = [
  "bindgen",
  "cc",
@@ -2099,6 +2099,7 @@ dependencies = [
  "libc",
  "once_cell",
  "phper",
+ "phper-build",
  "prost",
  "reqwest",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ url = "2.3.1"
 axum = "0.6.18"
 fastcgi-client = "0.8.0"
 reqwest = { version = "0.11.18", features = ["trust-dns", "json", "stream"] }
+
+[build-dependencies]
+phper-build = "0.12.0"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ SkyWalking PHP Agent requires SkyWalking 8.4+ and PHP 7.2+
 
 * Swoole Ecosystem
 
-  *The components of the PHP-FPM ecosystem can also be used in Swoole regardless of the flag `SWOOLE_HOOK_ALL`.
+  *The components of the PHP-FPM ecosystem can also be used in Swoole regardless of the flag `SWOOLE_HOOK_ALL`.*
 
 ## Contact Us
 

--- a/build.rs
+++ b/build.rs
@@ -14,9 +14,5 @@
 // limitations under the License.
 
 fn main() {
-    #[cfg(target_os = "macos")]
-    {
-        println!("cargo:rustc-link-arg=-undefined");
-        println!("cargo:rustc-link-arg=dynamic_lookup");
-    }
+    phper_build::register_all();
 }

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -599,7 +599,7 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/phper-alloc/0.12.0 0.12.0 MulanPSL-2.0
     https://crates.io/crates/phper-build/0.12.0 0.12.0 MulanPSL-2.0
     https://crates.io/crates/phper-macros/0.12.0 0.12.0 MulanPSL-2.0
-    https://crates.io/crates/phper-sys/0.12.0 0.12.0 MulanPSL-2.0
+    https://crates.io/crates/phper-sys/0.12.1 0.12.1 MulanPSL-2.0
 
 ========================================================================
 Unlicense licenses

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,12 @@ services:
 
   mysql:
     image: mysql:5.7.39
+    command:
+      - "mysqld"
+      - "--connect-timeout=60"
+      - "--wait-timeout=28800"
+      - "--max-allowed-packet=64M"
+      - "--net-buffer-length=16M"
     ports:
       - "3306:3306"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,12 +26,6 @@ services:
 
   mysql:
     image: mysql:5.7.39
-    command:
-      - "mysqld"
-      - "--connect-timeout=60"
-      - "--wait-timeout=28800"
-      - "--max-allowed-packet=64M"
-      - "--net-buffer-length=16M"
     ports:
       - "3306:3306"
     environment:

--- a/docs/en/configuration/ini-settings.md
+++ b/docs/en/configuration/ini-settings.md
@@ -19,3 +19,4 @@ This is the configuration list supported in `php.ini`.
 | skywalking_agent.ssl_cert_chain_path             | The certificate file. Enable mTLS when `ssl_key_path` and `ssl_cert_chain_path` exist.                                   |                           |
 | skywalking_agent.heartbeat_period                | Agent heartbeat report period. Unit, second.                                                                             | 30                        |
 | skywalking_agent.properties_report_period_factor | The agent sends the instance properties to the backend every heartbeat_period * properties_report_period_factor seconds. | 10                        |
+| skywalking_agent.enable_zend_observer            | Whether to use `zend observer` instead of `execute_ex` to hook the functions, this feature is only available for PHP8+.  | Off                       |

--- a/docs/en/configuration/ini-settings.md
+++ b/docs/en/configuration/ini-settings.md
@@ -19,4 +19,4 @@ This is the configuration list supported in `php.ini`.
 | skywalking_agent.ssl_cert_chain_path             | The certificate file. Enable mTLS when `ssl_key_path` and `ssl_cert_chain_path` exist.                                   |                           |
 | skywalking_agent.heartbeat_period                | Agent heartbeat report period. Unit, second.                                                                             | 30                        |
 | skywalking_agent.properties_report_period_factor | The agent sends the instance properties to the backend every heartbeat_period * properties_report_period_factor seconds. | 10                        |
-| skywalking_agent.enable_zend_observer            | Whether to use `zend observer` instead of `execute_ex` to hook the functions, this feature is only available for PHP8+.  | Off                       |
+| skywalking_agent.enable_zend_observer            | Whether to use `zend observer` instead of `zend_execute_ex` to hook the functions, this feature is only available for PHP8+.  | Off                       |

--- a/docs/en/configuration/zend-observer.md
+++ b/docs/en/configuration/zend-observer.md
@@ -1,0 +1,32 @@
+# Zend observer
+
+> Refer to: <https://www.datadoghq.com/blog/engineering/php-8-observability-baked-right-in/#the-observability-landscape-before-php-8>
+
+By default, skywalking-php hooks the `zend_execute_internal` and `zend_execute_ex` functions to implement auto instrumentation.
+
+But there are some drawbacks:
+
+- All PHP function calls are placed on the native C stack, which is limited by the value set in `ulimit -s`.
+- Not compatible with the new JIT added in PHP 8.
+
+## The observer API in PHP 8+
+
+Now, zend observer api is a new generation method, and it is also a method currently recommended by PHP8.
+
+This method has no stack problem and will not affect JIT.
+
+## Configuration
+
+The following configuration example enables JIT in PHP8 and zend observer support in skywalking-php at the same time.
+
+```ini
+[opcache]
+zend_extension = opcache
+; Enable JIT
+opcache.jit = tracing
+
+[skywalking_agent]
+extension = skywalking_agent.so
+; Switch to use zend observer api to implement auto instrumentation.
+skywalking_agent.enable_zend_observer = On
+```

--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -26,6 +26,8 @@ catalog:
     catalog:
       - name: "INI Settings"
         path: "/en/configuration/ini-settings"
+      - name: "Zend Observer"
+        path: "/en/configuration/zend-observer"
   - name: "Contribution"
     catalog:
       - name: "Compiling Guidance"

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -26,7 +26,7 @@ use phper::{
     values::{ExecuteData, ZVal},
 };
 use std::{any::Any, panic::AssertUnwindSafe, ptr::null_mut, sync::atomic::Ordering};
-use tracing::{error, info, trace};
+use tracing::{error, trace};
 
 pub type BeforeExecuteHook = dyn Fn(Option<i64>, &mut ExecuteData) -> crate::Result<Box<dyn Any>>;
 
@@ -303,7 +303,7 @@ fn infer_request_id(execute_data: &mut ExecuteData) -> Option<i64> {
 pub fn register_observer_handlers() {
     #[cfg(phper_major_version = "8")]
     unsafe {
-        info!("register zend observer handlers");
+        tracing::info!("register zend observer handlers");
         sys::zend_observer_fcall_register(Some(self::observer::observer_handler));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,9 @@ const SKYWALKING_AGENT_HEARTBEAT_PERIOD: &str = "skywalking_agent.heartbeat_peri
 const SKYWALKING_AGENT_PROPERTIES_REPORT_PERIOD_FACTOR: &str =
     "skywalking_agent.properties_report_period_factor";
 
-/// Whether to use zend observer instead of zend_execute_ex to hook the functions.
-/// This feature is only available for PHP8+, and can work with PHP8's jit.
+/// Whether to use zend observer instead of zend_execute_ex to hook the
+/// functions. This feature is only available for PHP8+, and can work with
+/// PHP8's jit.
 const SKYWALKING_AGENT_ENABLE_ZEND_OBSERVER: &str = "skywalking_agent.enable_zend_observer";
 
 #[php_get_module]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ const SKYWALKING_AGENT_HEARTBEAT_PERIOD: &str = "skywalking_agent.heartbeat_peri
 const SKYWALKING_AGENT_PROPERTIES_REPORT_PERIOD_FACTOR: &str =
     "skywalking_agent.properties_report_period_factor";
 
-/// Whether to use zend observer instead of execute_ex to hook the functions.
+/// Whether to use zend observer instead of zend_execute_ex to hook the functions.
 /// This feature is only available for PHP8+, and can work with PHP8's jit.
 const SKYWALKING_AGENT_ENABLE_ZEND_OBSERVER: &str = "skywalking_agent.enable_zend_observer";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,10 @@ const SKYWALKING_AGENT_HEARTBEAT_PERIOD: &str = "skywalking_agent.heartbeat_peri
 const SKYWALKING_AGENT_PROPERTIES_REPORT_PERIOD_FACTOR: &str =
     "skywalking_agent.properties_report_period_factor";
 
+/// Whether to use zend observer instead of execute_ex to hook the functions.
+/// This feature is only available for PHP8+, and can work with PHP8's jit.
+const SKYWALKING_AGENT_ENABLE_ZEND_OBSERVER: &str = "skywalking_agent.enable_zend_observer";
+
 #[php_get_module]
 pub fn get_module() -> Module {
     let mut module = Module::new(
@@ -147,6 +151,7 @@ pub fn get_module() -> Module {
         10i64,
         Policy::System,
     );
+    module.add_ini(SKYWALKING_AGENT_ENABLE_ZEND_OBSERVER, false, Policy::System);
 
     // Hooks.
     module.on_module_init(module::init);

--- a/src/module.rs
+++ b/src/module.rs
@@ -15,15 +15,10 @@
 
 use crate::{
     channel::Reporter,
-    execute::register_execute_functions,
+    execute::{register_execute_functions, register_observer_handlers},
     util::{get_sapi_module_name, IPS},
     worker::init_worker,
-    SKYWALKING_AGENT_AUTHENTICATION, SKYWALKING_AGENT_ENABLE, SKYWALKING_AGENT_ENABLE_TLS,
-    SKYWALKING_AGENT_HEARTBEAT_PERIOD, SKYWALKING_AGENT_LOG_FILE, SKYWALKING_AGENT_LOG_LEVEL,
-    SKYWALKING_AGENT_PROPERTIES_REPORT_PERIOD_FACTOR, SKYWALKING_AGENT_RUNTIME_DIR,
-    SKYWALKING_AGENT_SERVICE_NAME, SKYWALKING_AGENT_SKYWALKING_VERSION,
-    SKYWALKING_AGENT_SSL_CERT_CHAIN_PATH, SKYWALKING_AGENT_SSL_KEY_PATH,
-    SKYWALKING_AGENT_SSL_TRUSTED_CA_PATH,
+    *,
 };
 use anyhow::bail;
 use once_cell::sync::Lazy;
@@ -117,6 +112,10 @@ pub static HEARTBEAT_PERIOD: Lazy<i64> =
 pub static PROPERTIES_REPORT_PERIOD_FACTOR: Lazy<i64> =
     Lazy::new(|| ini_get::<i64>(SKYWALKING_AGENT_PROPERTIES_REPORT_PERIOD_FACTOR));
 
+pub static ENABLE_ZEND_OBSERVER: Lazy<bool> = Lazy::new(|| {
+    cfg!(phper_major_version = "8") && ini_get::<bool>(SKYWALKING_AGENT_ENABLE_ZEND_OBSERVER)
+});
+
 pub fn init() {
     if !is_enable() {
         return;
@@ -183,7 +182,11 @@ pub fn init() {
     ));
 
     // Hook functions.
-    register_execute_functions();
+    if *ENABLE_ZEND_OBSERVER {
+        register_observer_handlers();
+    } else {
+        register_execute_functions();
+    }
 }
 
 pub fn shutdown() {

--- a/src/plugin/plugin_pdo.rs
+++ b/src/plugin/plugin_pdo.rs
@@ -202,6 +202,10 @@ fn after_hook(
 ) -> crate::Result<()> {
     let mut span = span.downcast::<Span>().unwrap();
 
+    if log_exception(&mut *span).is_some() {
+        return Ok(());
+    }
+
     if let Some(b) = return_value.as_bool() {
         if !b {
             return after_hook_when_false(get_this_mut(execute_data)?, &mut span);
@@ -216,8 +220,6 @@ fn after_hook(
             debug!(cls, "not a subclass of PDOStatement");
         }
     }
-
-    log_exception(&mut *span);
 
     Ok(())
 }

--- a/src/plugin/plugin_predis.rs
+++ b/src/plugin/plugin_predis.rs
@@ -164,11 +164,6 @@ impl Plugin for PredisPlugin {
         Box<crate::execute::AfterExecuteHook>,
     )> {
         match (class_name, function_name) {
-            (Some(class_name @ "Predis\\Client"), function_name)
-                if REDIS_ALL_COMMANDS.contains(&*function_name.to_ascii_uppercase()) =>
-            {
-                Some(self.hook_predis_execute_command(class_name, function_name))
-            }
             (Some(class_name @ "Predis\\Client"), "__call") => {
                 Some(self.hook_predis_execute_command(class_name, function_name))
             }
@@ -184,32 +179,31 @@ enum ConnectionType {
 
 impl PredisPlugin {
     fn hook_predis_execute_command(
-        &self, class_name: &str, function_name: &str,
+        &self, class_name: &str, _function_name: &str,
     ) -> (Box<BeforeExecuteHook>, Box<AfterExecuteHook>) {
         let class_name = class_name.to_owned();
-        let function_name = function_name.to_owned();
         (
             Box::new(move |request_id, execute_data| {
-                let is_call_method = function_name == "__call";
+                validate_num_args(execute_data, 1)?;
 
-                validate_num_args(execute_data, if is_call_method { 1 } else { 0 })?;
+                let function_name = execute_data
+                    .get_parameter(0)
+                    .as_z_str()
+                    .and_then(|s| s.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+
+                let cmd = function_name.to_uppercase();
+
+                if !REDIS_ALL_COMMANDS.contains(&*cmd) {
+                    return Ok(Box::new(()));
+                }
 
                 let this = get_this_mut(execute_data)?;
                 let handle = this.handle();
                 let connection = this.call("getConnection", [])?;
 
                 let peer = Self::get_peer(connection)?;
-
-                let cmd = if is_call_method {
-                    execute_data
-                        .get_parameter(0)
-                        .as_z_str()
-                        .and_then(|s| s.to_str().ok())
-                        .unwrap_or("")
-                        .to_string()
-                } else {
-                    function_name.to_ascii_uppercase()
-                };
 
                 let op = if REDIS_READ_COMMANDS.contains(&*cmd) {
                     Some("read")
@@ -220,25 +214,20 @@ impl PredisPlugin {
                 };
 
                 let key = op
-                    .and_then(|_| {
-                        execute_data
-                            .get_parameter(if is_call_method { 1 } else { 0 })
-                            .as_z_str()
-                    })
+                    .and_then(|_| execute_data.get_parameter(1).as_z_arr())
+                    .and_then(|params| params.get(0))
+                    .and_then(|key| key.as_z_str())
                     .and_then(|s| s.to_str().ok());
 
                 debug!(handle, cmd, key, op, "call redis command");
 
-                let mut span = RequestContext::try_with_global_ctx(request_id, |ctx| {
-                    Ok(ctx.create_exit_span(
-                        &format!(
-                            "{}->{}",
-                            class_name,
-                            if is_call_method { &cmd } else { &function_name }
-                        ),
-                        &peer,
-                    ))
-                })?;
+                let mut span =
+                    RequestContext::try_with_global_ctx(request_id, |ctx| {
+                        Ok(ctx.create_exit_span(
+                            &format!("{}->{}", class_name, &function_name,),
+                            &peer,
+                        ))
+                    })?;
 
                 let mut span_object = span.span_object_mut();
                 span_object.set_span_layer(SpanLayer::Cache);
@@ -255,6 +244,10 @@ impl PredisPlugin {
                 Ok(Box::new(span))
             }),
             Box::new(move |_, span, _, return_value| {
+                if span.downcast_ref::<()>().is_some() {
+                    return Ok(());
+                }
+
                 let mut span = span.downcast::<Span>().unwrap();
 
                 let exception = unsafe { eg!(exception) };

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -17,11 +17,11 @@
 //!
 //! Virtual Cache
 //!
-//! https://skywalking.apache.org/docs/main/next/en/setup/service-agent/virtual-cache/
+//! <https://skywalking.apache.org/docs/main/next/en/setup/service-agent/virtual-cache/>
 //!
 //! Virtual Database
 //!
-//! https://skywalking.apache.org/docs/main/next/en/setup/service-agent/virtual-database/
+//! <https://skywalking.apache.org/docs/main/next/en/setup/service-agent/virtual-database/>
 
 use std::fmt::Display;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -69,13 +69,8 @@ pub const EXT: &str = if cfg!(target_os = "linux") {
     ""
 };
 
-pub static ENABLE_ZEND_OBSERVER: Lazy<&str> = Lazy::new(|| {
-    if env::var("ENABLE_ZEND_OBSERVER").is_ok() {
-        "On"
-    } else {
-        "Off"
-    }
-});
+pub static ENABLE_ZEND_OBSERVER: Lazy<String> =
+    Lazy::new(|| env::var("ENABLE_ZEND_OBSERVER").unwrap_or_else(|_| "Off".to_owned()));
 
 pub static HTTP_CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
 

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -684,9 +684,9 @@ segmentItems:
               }
             logs:
               - logEvent:
-                - { key: SQLSTATE, value: 42S02 }
-                - { key: Error Code, value: '1146' }
-                - { key: Error, value: "Table 'skywalking.not_exist' doesn't exist" }
+                  - { key: error.kind, value: PDOException }
+                  - { key: message, value: not null }
+                  - { key: stack, value: not null }
           - operationName: GET:/pdo.php
             parentSpanId: -1
             spanId: 0

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -215,6 +215,6 @@ async fn request_common(request_builder: RequestBuilder, actual_content: impl In
     let response = request_builder.send().await.unwrap();
     let status = response.status();
     let content = response.text().await.unwrap();
-    info!(content, "response content");
+    info!("response content: {}", content);
     assert_eq!((status, content), (StatusCode::OK, actual_content.into()));
 }


### PR DESCRIPTION
According to <https://www.datadoghq.com/blog/engineering/php-8-observability-baked-right-in/>, the observer API in PHP 8, being able to work well with jit is a more recommended approach in PHP 8.

Therefore, add a switch to selectively enable zebd observer support for PHP 8.
