### PR TITLE
Fix the empty span situation in redis after hook.

### DIFF
--- a/src/plugin/plugin_redis.rs
+++ b/src/plugin/plugin_redis.rs
@@ -355,6 +355,10 @@ fn after_hook(
     _request_id: Option<i64>, span: Box<dyn Any>, _execute_data: &mut ExecuteData,
     _return_value: &mut ZVal,
 ) -> crate::Result<()> {
+    if span.downcast_ref::<()>().is_some() {
+        return Ok(());
+    }
+
     let mut span = span.downcast::<Span>().unwrap();
 
     log_exception(&mut *span);


### PR DESCRIPTION
Fix the first error mention in https://github.com/apache/skywalking/issues/11041
> thread '' panicked at 'called Result::unwrap() on an Err value: Any { .. }', src/plugin/plugin_redis.rs:361:44