### PR TITLE
Refactor mysqli plugin, support procedural api.

### DIFF
--- a/src/plugin/plugin_memcache.rs
+++ b/src/plugin/plugin_memcache.rs
@@ -249,7 +249,7 @@ fn create_exit_span(
 ) -> anyhow::Result<Span> {
     RequestContext::try_with_global_ctx(request_id, |ctx| {
         let mut span = ctx.create_exit_span(
-            &style.generate_peer_name(class_name, function_name),
+            &style.generate_operation_name(class_name, function_name),
             remote_peer,
         );
 

--- a/src/plugin/style.rs
+++ b/src/plugin/style.rs
@@ -48,7 +48,6 @@ impl ApiStyle {
         execute_data.get_mut_parameter(index)
     }
 
-    #[allow(dead_code)]
     pub fn validate_num_args(
         self, execute_data: &mut ExecuteData, num: usize,
     ) -> anyhow::Result<()> {
@@ -59,7 +58,7 @@ impl ApiStyle {
         validate_num_args(execute_data, num)
     }
 
-    pub fn generate_peer_name(self, class_name: Option<&str>, function_name: &str) -> String {
+    pub fn generate_operation_name(self, class_name: Option<&str>, function_name: &str) -> String {
         match self {
             ApiStyle::OO => format!("{}->{}", class_name.unwrap_or_default(), function_name),
             ApiStyle::Procedural => function_name.to_owned(),

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -834,6 +834,45 @@ segmentItems:
                   key: db.statement,
                   value: "SELECT * FROM `mysql`.`user` WHERE `User` = 'root'",
                 }
+          - operationName: mysqli_connect
+            parentSpanId: 0
+            spanId: 5
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8004
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+          - operationName: mysqli_query
+            parentSpanId: 0
+            spanId: 6
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8004
+            isError: false
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
+          - operationName: mysqli_real_connect
+            parentSpanId: 0
+            spanId: 7
+            spanLayer: Database
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 8004
+            isError: true
+            spanType: Exit
+            peer: 127.0.0.1:3306
+            skipAnalysis: false
+            tags:
+              - { key: db.type, value: mysql }
           - operationName: GET:/mysqli.php
             parentSpanId: -1
             spanId: 0

--- a/tests/php/fpm/mysqli.php
+++ b/tests/php/fpm/mysqli.php
@@ -32,4 +32,16 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
     Assert::same(count($rs), 2);
 }
 
+{
+    $mysqli = mysqli_connect("127.0.0.1", "root", "password", "skywalking", 3306);
+    $result = mysqli_query($mysqli, "SELECT * FROM `mysql`.`user` WHERE `User` = 'root'");
+    $rs = $result->fetch_all();
+    Assert::same(count($rs), 2);
+}
+
+{
+    $mysqli = mysqli_init();
+    @mysqli_real_connect($mysqli, "127.0.0.1", "root", "password_incorrect", "skywalking", 3306);
+}
+
 echo "ok";

--- a/tests/php/fpm/mysqli.php
+++ b/tests/php/fpm/mysqli.php
@@ -40,6 +40,7 @@ require_once dirname(__DIR__) . "/vendor/autoload.php";
 }
 
 {
+    mysqli_report(MYSQLI_REPORT_OFF);
     $mysqli = mysqli_init();
     @mysqli_real_connect($mysqli, "127.0.0.1", "root", "password_incorrect", "skywalking", 3306);
 }


### PR DESCRIPTION
1. Refactor mysqli plugin, getting peer by properties, rather than hacking by `MYSQL_MAP`.
2. Support both OO and procedural apis.