### PR TITLE
Fix target address in cross process header.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -56,18 +56,18 @@ impl RequestContext {
         Self::try_with_global(request_id, |ctx| f(&mut ctx.tracing_context))
     }
 
-    pub fn try_get_sw_header(request_id: Option<i64>) -> crate::Result<String> {
+    pub fn try_get_sw_header(request_id: Option<i64>, peer: &str) -> crate::Result<String> {
         Ok(Self::try_with_global(request_id, |req_ctx| {
-            let span_object = req_ctx.get_primary_span().span_object();
             Ok(encode_propagation(
                 &req_ctx.tracing_context,
-                &span_object.operation_name,
-                &span_object.peer,
+                &req_ctx.get_primary_span().span_object().operation_name,
+                peer,
             ))
         })?)
     }
 
     /// Primary endpoint name is used for endpoint dependency.
+    #[inline]
     fn get_primary_span(&self) -> &Span {
         &self.entry_span
     }

--- a/src/plugin/plugin_amqplib.rs
+++ b/src/plugin/plugin_amqplib.rs
@@ -98,7 +98,7 @@ impl AmqplibPlugin {
                     &routing_key,
                 )?;
 
-                Self::inject_sw_header(request_id, execute_data)?;
+                Self::inject_sw_header(request_id, execute_data, &peer)?;
 
                 Ok(Box::new(span))
             }),
@@ -146,11 +146,11 @@ impl AmqplibPlugin {
     }
 
     fn inject_sw_header(
-        request_id: Option<i64>, execute_data: &mut ExecuteData,
+        request_id: Option<i64>, execute_data: &mut ExecuteData, peer: &str,
     ) -> crate::Result<()> {
         const HEADER_NAME: &str = "application_headers";
 
-        let sw_header = RequestContext::try_get_sw_header(request_id)?;
+        let sw_header = RequestContext::try_get_sw_header(request_id, peer)?;
 
         let message = execute_data
             .get_mut_parameter(0)

--- a/src/plugin/plugin_curl.rs
+++ b/src/plugin/plugin_curl.rs
@@ -402,7 +402,7 @@ impl CurlPlugin {
     }
 
     fn inject_sw_header(request_id: Option<i64>, ch: ZVal, info: &CurlInfo) -> crate::Result<()> {
-        let sw_header = RequestContext::try_get_sw_header(request_id)?;
+        let sw_header = RequestContext::try_get_sw_header(request_id, &info.peer)?;
         let mut val = CURL_HEADERS
             .with(|headers| headers.borrow_mut().remove(&info.cid))
             .unwrap_or_else(|| ZVal::from(ZArray::new()));

--- a/tests/data/expected_context.yaml
+++ b/tests/data/expected_context.yaml
@@ -37,7 +37,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -68,7 +68,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 2,
                   parentTraceSegmentId: "not null",
@@ -99,7 +99,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 3,
                   parentTraceSegmentId: "not null",
@@ -130,7 +130,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 4,
                   parentTraceSegmentId: "not null",
@@ -158,7 +158,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/guzzle.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -285,7 +285,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl-multi.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -316,7 +316,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl-multi.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 3,
                   parentTraceSegmentId: "not null",
@@ -347,7 +347,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl-multi.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9011",
                   refType: CrossProcess,
                   parentSpanId: 2,
                   parentTraceSegmentId: "not null",
@@ -1474,7 +1474,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl.enter.php",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9012",
                   refType: CrossProcess,
                   parentSpanId: 5,
                   parentTraceSegmentId: "not null",
@@ -1505,7 +1505,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9501",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",
@@ -1581,7 +1581,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9502",
                   refType: CrossProcess,
                   parentSpanId: 2,
                   parentTraceSegmentId: "not null",
@@ -1609,7 +1609,7 @@ segmentItems:
             refs:
               - {
                   parentEndpoint: "GET:/curl",
-                  networkAddress: "",
+                  networkAddress: "127.0.0.1:9502",
                   refType: CrossProcess,
                   parentSpanId: 1,
                   parentTraceSegmentId: "not null",


### PR DESCRIPTION
Previous the target address in cross process header is the peer of entry span, which is wrong, now fix it.