### PR TITLE
Release SkyWalking PHP 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "skywalking-php"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 
 [package]
 name = "skywalking-php"
-version = "0.7.0-dev"
+version = "0.7.0"
 authors = ["Apache Software Foundation", "jmjoy <jmjoy@apache.org>", "Yanlong He <heyanlong@apache.org>"]
 description = "Apache SkyWalking PHP Agent."
 edition = "2021"

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -223,7 +223,6 @@ The text of each license is the standard Apache 2.0 license.
     https://crates.io/crates/prost-types/0.11.9 0.11.9 Apache-2.0
     https://crates.io/crates/scripts/0.0.0 0.0.0 Apache-2.0
     https://crates.io/crates/skywalking/0.8.0 0.8.0 Apache-2.0
-    https://crates.io/crates/skywalking-php/0.7.0-dev 0.7.0-dev Apache-2.0
     https://crates.io/crates/sync_wrapper/0.1.2 0.1.2 Apache-2.0
 
 ========================================================================

--- a/dist-material/LICENSE.tpl
+++ b/dist-material/LICENSE.tpl
@@ -20,7 +20,6 @@ The text of each license is the standard Apache 2.0 license.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 {{ end }}
 
-    {{- range .Deps }}
-    https://crates.io/crates/{{ .Name }}/{{ .Version }} {{ .Version }} {{ .LicenseID }}
-    {{- end }}
+{{- range .Deps }}{{ if ne .Name "skywalking-php"  }}
+    https://crates.io/crates/{{ .Name }}/{{ .Version }} {{ .Version }} {{ .LicenseID }}{{ end }}{{- end }}
 {{ end }}


### PR DESCRIPTION
1. Release SkyWalking PHP 0.7.0.
2. Remove `skywalking-php` itself in dependencies LICENSES.