### PR TITLE
Updated skywalking dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -147,18 +147,17 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "http-body-util",
  "itoa",
  "matchit 0.7.3",
  "memchr",
@@ -167,26 +166,26 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
+ "sync_wrapper",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
- "axum-core 0.5.0",
+ "axum-core 0.5.2",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -199,7 +198,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -209,36 +208,39 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "futures-core",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -258,18 +260,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -303,25 +293,19 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease 0.2.31",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.100",
+ "syn",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -340,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "serde",
@@ -362,15 +346,15 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytesize"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -437,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -447,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -463,10 +447,10 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -486,6 +470,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -581,7 +575,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -608,7 +602,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -646,9 +640,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -673,9 +667,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
@@ -736,7 +730,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -832,28 +826,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "ignore",
  "walkdir",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.8.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -867,8 +842,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.8.0",
+ "http",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -895,56 +870,19 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
-
-[[package]]
-name = "hostname"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
+ "windows-link",
 ]
 
 [[package]]
@@ -960,23 +898,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -987,8 +914,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1015,30 +942,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -1046,9 +949,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1065,26 +968,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.3.1",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.25",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower-service",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 0.14.32",
+ "hyper",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -1095,7 +999,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1105,16 +1009,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1124,14 +1029,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1186,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -1210,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -1231,9 +1137,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -1260,7 +1166,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1312,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1331,15 +1237,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1417,15 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1445,15 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -1496,9 +1381,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1516,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
@@ -1532,7 +1417,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1590,7 +1475,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1613,17 +1498,17 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1640,7 +1525,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1651,9 +1536,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -1717,9 +1602,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -1728,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1738,22 +1623,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -1762,12 +1647,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -1810,14 +1695,13 @@ dependencies = [
 
 [[package]]
 name = "phper"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9b964d2e01253454c9a21e6380ab5c004ca8b128f0cecc17c8f88522570135"
+checksum = "dccb9385f3420063db05d51345671d21897a93e246abb179cd2c38f39565b2f0"
 dependencies = [
  "cfg-if",
  "derive_more",
- "indexmap 2.8.0",
- "once_cell",
+ "indexmap 2.9.0",
  "phper-alloc",
  "phper-build",
  "phper-macros",
@@ -1827,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "phper-alloc"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3052dc5ba0c3d13c07fbdd4820f9f0276a9b8afed4c84267af2ab59ff0b866"
+checksum = "28744354cf67a6cf5b4da5141cfe159f4b844046e8601dc3f8c9cc3e2f48a725"
 dependencies = [
  "phper-build",
  "phper-sys",
@@ -1837,29 +1721,29 @@ dependencies = [
 
 [[package]]
 name = "phper-build"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e626e7fd9ede08f05d0c7f5b9247ae71da88223ab47cc1b496d4c1afec1a7d"
+checksum = "9fe370f68053c65411f61b37643765de47527afae06e9a3d7e72b8da52e97ea8"
 dependencies = [
  "phper-sys",
 ]
 
 [[package]]
 name = "phper-macros"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d372ca9fb2bfb977d8189bfd8d322d41a8d3c4294111df14bfa99318dbc9747"
+checksum = "eef2c2105b6d720e987e862b1beeaa8ee189c4a4fa0dc0a0119996fabf518df0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "phper-sys"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23008d96066ac458fc1442f7429562baea8867e82652ae035cb071683be51eb4"
+checksum = "269f6cefb64a4b920a9e6e4934a495125cfc56159a5d0cb3c2d7e0941fdbe251"
 dependencies = [
  "bindgen",
  "cc",
@@ -1883,7 +1767,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1903,15 +1787,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "portable-atomic"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
-dependencies = [
- "portable-atomic 1.11.0",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -1936,22 +1811,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
-dependencies = [
- "proc-macro2",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1974,57 +1839,32 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.13.5",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
+ "heck",
+ "itertools 0.14.0",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
+ "prettyplease",
+ "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn",
  "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2037,16 +1877,16 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost 0.11.9",
+ "prost",
 ]
 
 [[package]]
@@ -2096,24 +1936,6 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8733bc5dc0b192d1a4b28073f9bff1326ad9e4fecd4d9b025d6fc358d1c3e79"
-dependencies = [
- "futures-channel",
- "futures-util",
- "libc",
- "log",
- "rdkafka-sys",
- "serde",
- "serde_derive",
- "serde_json",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "rdkafka"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
@@ -2146,11 +1968,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2203,16 +2025,16 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -2224,11 +2046,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2245,21 +2067,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -2268,7 +2075,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2286,49 +2093,26 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "log",
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
-dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2337,23 +2121,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pki-types",
  "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -2373,13 +2148,13 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2444,23 +2219,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2493,7 +2271,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2502,7 +2280,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2584,26 +2362,24 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skywalking"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10d03f205ab1fb2cf9848779a5a954ba174503161908b81bcc812f6264e7728"
+checksum = "53125a8779002fea3646d81269f47255aa8fc8e6bfcf7dc55d8bf808029eec9e"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "cfg-if",
  "futures-core",
  "futures-util",
- "hostname 0.3.1",
- "libz-sys",
- "once_cell",
+ "hostname",
  "parking_lot",
- "portable-atomic 0.3.20",
- "prost 0.11.9",
- "prost-derive 0.11.9",
- "rdkafka 0.32.2",
+ "portable-atomic",
+ "prost",
+ "prost-derive",
+ "rdkafka",
  "serde",
  "systemstat",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2617,18 +2393,18 @@ name = "skywalking-php"
 version = "1.0.0-dev"
 dependencies = [
  "anyhow",
- "axum 0.8.1",
+ "axum 0.8.3",
  "bincode",
  "dashmap",
  "fastcgi-client",
  "futures-util",
- "hostname 0.4.0",
+ "hostname",
  "libc",
  "once_cell",
  "phper",
  "phper-build",
- "prost 0.13.5",
- "rdkafka 0.37.0",
+ "prost",
+ "rdkafka",
  "reqwest",
  "skywalking",
  "skywalking-php-worker",
@@ -2652,8 +2428,8 @@ dependencies = [
  "clap",
  "libc",
  "once_cell",
- "prost 0.13.5",
- "rdkafka 0.37.0",
+ "prost",
+ "rdkafka",
  "serde_json",
  "skywalking",
  "tokio",
@@ -2684,25 +2460,19 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2724,17 +2494,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -2743,12 +2502,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -2767,7 +2520,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2776,8 +2529,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2807,14 +2560,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2866,7 +2619,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2877,7 +2630,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2892,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -2915,9 +2668,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2935,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2952,16 +2705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,7 +2712,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2984,22 +2727,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.25",
+ "rustls",
  "tokio",
 ]
 
@@ -3039,57 +2771,56 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
- "base64 0.13.1",
+ "axum 0.7.9",
+ "base64",
  "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.11.9",
- "prost-derive 0.11.9",
+ "prost",
  "rustls-native-certs",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
+ "socket2",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-stream",
- "tokio-util",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
- "prettyplease 0.1.25",
+ "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -3121,7 +2852,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3160,7 +2891,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -3171,16 +2902,6 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -3286,12 +3007,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3424,7 +3139,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3459,7 +3174,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3497,28 +3212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,22 +3243,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.52.0"
+name = "windows-core"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.0",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows-implement"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
- "windows-targets 0.52.6",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3581,7 +3290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -3599,6 +3308,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]
@@ -3751,9 +3469,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
@@ -3764,7 +3482,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3799,28 +3517,28 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -3840,7 +3558,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "synstructure",
 ]
 
@@ -3869,5 +3587,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,31 +55,31 @@ anyhow = { version = "1.0.97", features = ["backtrace"] }
 bincode = { workspace = true }
 dashmap = "6.1.0"
 futures-util = "0.3.31"
-hostname = "0.4.0"
+hostname = "0.4.1"
 libc = "0.2.171"
-once_cell = "1.21.1"
-phper = "0.15.1"
+once_cell = "1.21.3"
+phper = "0.16.0"
 prost = "0.13.5"
 rdkafka = { version = "0.37.0", optional = true }
-skywalking = { version = "0.8.0", features = ["management"] }
+skywalking = { version = "0.9.0", features = ["management"] }
 skywalking-php-worker = { path = "worker" }
 systemstat = "0.2.4"
 thiserror = "2.0.12"
 time = { version = "0.3", features = ["formatting"] }
-tokio = { version = "1.44.1", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-stream = "0.1.17"
-tonic = { version = "0.8.3", features = ["tls", "tls-roots"] }
+tonic = { version = "0.12.0", features = ["tls-native-roots"] }
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "time", "local-time"] }
 url = "2.5.4"
 
 [dev-dependencies]
-axum = "0.8.1"
+axum = "0.8.3"
 fastcgi-client = "0.9.0"
 reqwest = { version = "0.12.15", features = ["trust-dns", "json", "stream"] }
 
 [build-dependencies]
-phper-build = "0.15.0"
+phper-build = "0.15.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(phper_major_version, values("8"))'] }

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -213,20 +213,17 @@ Apache-2.0 licenses
 ========================================================================
 The following components are provided under the Apache-2.0 License. See project link for details.
 The text of each license is the standard Apache 2.0 license.
-    https://crates.io/crates/bytesize/1.3.2 1.3.2 Apache-2.0
+    https://crates.io/crates/bytesize/1.3.3 1.3.3 Apache-2.0
     https://crates.io/crates/clang-sys/1.8.1 1.8.1 Apache-2.0
     https://crates.io/crates/fastcgi-client/0.9.0 0.9.0 Apache-2.0
-    https://crates.io/crates/openssl/0.10.71 0.10.71 Apache-2.0
-    https://crates.io/crates/prost/0.11.9 0.11.9 Apache-2.0
+    https://crates.io/crates/openssl/0.10.72 0.10.72 Apache-2.0
     https://crates.io/crates/prost/0.13.5 0.13.5 Apache-2.0
-    https://crates.io/crates/prost-build/0.11.9 0.11.9 Apache-2.0
-    https://crates.io/crates/prost-derive/0.11.9 0.11.9 Apache-2.0
+    https://crates.io/crates/prost-build/0.13.5 0.13.5 Apache-2.0
     https://crates.io/crates/prost-derive/0.13.5 0.13.5 Apache-2.0
-    https://crates.io/crates/prost-types/0.11.9 0.11.9 Apache-2.0
+    https://crates.io/crates/prost-types/0.13.5 0.13.5 Apache-2.0
     https://crates.io/crates/sasl2-sys/0.1.22+2.1.28 0.1.22+2.1.28 Apache-2.0
     https://crates.io/crates/scripts/0.0.0 0.0.0 Apache-2.0
-    https://crates.io/crates/skywalking/0.8.0 0.8.0 Apache-2.0
-    https://crates.io/crates/sync_wrapper/0.1.2 0.1.2 Apache-2.0
+    https://crates.io/crates/skywalking/0.9.0 0.9.0 Apache-2.0
     https://crates.io/crates/sync_wrapper/1.0.2 1.0.2 Apache-2.0
 
 ========================================================================
@@ -243,10 +240,8 @@ Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT licenses
 The following components are provided under the Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/linux-raw-sys/0.4.15 0.4.15 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-    https://crates.io/crates/linux-raw-sys/0.9.3 0.9.3 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-    https://crates.io/crates/rustix/0.38.44 0.38.44 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
-    https://crates.io/crates/rustix/1.0.3 1.0.3 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+    https://crates.io/crates/linux-raw-sys/0.9.4 0.9.4 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+    https://crates.io/crates/rustix/1.0.5 1.0.5 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
     https://crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1 0.11.0+wasi-snapshot-preview1 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
     https://crates.io/crates/wasi/0.14.2+wasi-0.2.4 0.14.2+wasi-0.2.4 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
     https://crates.io/crates/wit-bindgen-rt/0.39.0 0.39.0 Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
@@ -257,8 +252,8 @@ Apache-2.0 OR BSD-2-Clause OR MIT licenses
 The following components are provided under the Apache-2.0 OR BSD-2-Clause OR MIT License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/zerocopy/0.8.23 0.8.23 Apache-2.0 OR BSD-2-Clause OR MIT
-    https://crates.io/crates/zerocopy-derive/0.8.23 0.8.23 Apache-2.0 OR BSD-2-Clause OR MIT
+    https://crates.io/crates/zerocopy/0.8.24 0.8.24 Apache-2.0 OR BSD-2-Clause OR MIT
+    https://crates.io/crates/zerocopy-derive/0.8.24 0.8.24 Apache-2.0 OR BSD-2-Clause OR MIT
 
 ========================================================================
 Apache-2.0 OR BSD-3-Clause OR MIT licenses
@@ -284,12 +279,9 @@ The following components are provided under the Apache-2.0 OR ISC OR MIT License
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://crates.io/crates/hyper-rustls/0.27.5 0.27.5 Apache-2.0 OR ISC OR MIT
-    https://crates.io/crates/rustls/0.20.9 0.20.9 Apache-2.0 OR ISC OR MIT
-    https://crates.io/crates/rustls/0.23.25 0.23.25 Apache-2.0 OR ISC OR MIT
-    https://crates.io/crates/rustls-native-certs/0.6.3 0.6.3 Apache-2.0 OR ISC OR MIT
-    https://crates.io/crates/rustls-pemfile/1.0.4 1.0.4 Apache-2.0 OR ISC OR MIT
+    https://crates.io/crates/rustls/0.23.26 0.23.26 Apache-2.0 OR ISC OR MIT
+    https://crates.io/crates/rustls-native-certs/0.8.1 0.8.1 Apache-2.0 OR ISC OR MIT
     https://crates.io/crates/rustls-pemfile/2.2.0 2.2.0 Apache-2.0 OR ISC OR MIT
-    https://crates.io/crates/sct/0.7.1 0.7.1 Apache-2.0 OR ISC OR MIT
 
 ========================================================================
 Apache-2.0 OR LGPL-2.1-or-later OR MIT licenses
@@ -318,26 +310,24 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/atomic-waker/1.1.2 1.1.2 Apache-2.0 OR MIT
     https://crates.io/crates/autocfg/1.4.0 1.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/backtrace/0.3.74 0.3.74 Apache-2.0 OR MIT
-    https://crates.io/crates/base64/0.13.1 0.13.1 Apache-2.0 OR MIT
-    https://crates.io/crates/base64/0.21.7 0.21.7 Apache-2.0 OR MIT
     https://crates.io/crates/base64/0.22.1 0.22.1 Apache-2.0 OR MIT
-    https://crates.io/crates/bitflags/1.3.2 1.3.2 Apache-2.0 OR MIT
     https://crates.io/crates/bitflags/2.9.0 2.9.0 Apache-2.0 OR MIT
     https://crates.io/crates/block-buffer/0.10.4 0.10.4 Apache-2.0 OR MIT
-    https://crates.io/crates/bstr/1.11.3 1.11.3 Apache-2.0 OR MIT
+    https://crates.io/crates/bstr/1.12.0 1.12.0 Apache-2.0 OR MIT
     https://crates.io/crates/bumpalo/3.17.0 3.17.0 Apache-2.0 OR MIT
-    https://crates.io/crates/cc/1.2.16 1.2.16 Apache-2.0 OR MIT
+    https://crates.io/crates/cc/1.2.19 1.2.19 Apache-2.0 OR MIT
     https://crates.io/crates/cexpr/0.6.0 0.6.0 Apache-2.0 OR MIT
     https://crates.io/crates/cfg-if/1.0.0 1.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/chrono/0.4.40 0.4.40 Apache-2.0 OR MIT
     https://crates.io/crates/chrono-tz/0.9.0 0.9.0 Apache-2.0 OR MIT
     https://crates.io/crates/chrono-tz-build/0.3.0 0.3.0 Apache-2.0 OR MIT
-    https://crates.io/crates/clap/4.5.32 4.5.32 Apache-2.0 OR MIT
-    https://crates.io/crates/clap_builder/4.5.32 4.5.32 Apache-2.0 OR MIT
+    https://crates.io/crates/clap/4.5.36 4.5.36 Apache-2.0 OR MIT
+    https://crates.io/crates/clap_builder/4.5.36 4.5.36 Apache-2.0 OR MIT
     https://crates.io/crates/clap_derive/4.5.32 4.5.32 Apache-2.0 OR MIT
     https://crates.io/crates/clap_lex/0.7.4 0.7.4 Apache-2.0 OR MIT
     https://crates.io/crates/colorchoice/1.0.3 1.0.3 Apache-2.0 OR MIT
     https://crates.io/crates/core-foundation/0.9.4 0.9.4 Apache-2.0 OR MIT
+    https://crates.io/crates/core-foundation/0.10.0 0.10.0 Apache-2.0 OR MIT
     https://crates.io/crates/core-foundation-sys/0.8.7 0.8.7 Apache-2.0 OR MIT
     https://crates.io/crates/cpufeatures/0.2.17 0.2.17 Apache-2.0 OR MIT
     https://crates.io/crates/crossbeam-deque/0.8.6 0.8.6 Apache-2.0 OR MIT
@@ -349,9 +339,9 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/displaydoc/0.2.5 0.2.5 Apache-2.0 OR MIT
     https://crates.io/crates/either/1.15.0 1.15.0 Apache-2.0 OR MIT
     https://crates.io/crates/equivalent/1.0.2 1.0.2 Apache-2.0 OR MIT
-    https://crates.io/crates/errno/0.3.10 0.3.10 Apache-2.0 OR MIT
+    https://crates.io/crates/errno/0.3.11 0.3.11 Apache-2.0 OR MIT
     https://crates.io/crates/fastrand/2.3.0 2.3.0 Apache-2.0 OR MIT
-    https://crates.io/crates/fixedbitset/0.4.2 0.4.2 Apache-2.0 OR MIT
+    https://crates.io/crates/fixedbitset/0.5.7 0.5.7 Apache-2.0 OR MIT
     https://crates.io/crates/fnv/1.0.7 1.0.7 Apache-2.0 OR MIT
     https://crates.io/crates/foreign-types/0.3.2 0.3.2 Apache-2.0 OR MIT
     https://crates.io/crates/foreign-types-shared/0.1.1 0.1.1 Apache-2.0 OR MIT
@@ -370,25 +360,21 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/hashbrown/0.12.3 0.12.3 Apache-2.0 OR MIT
     https://crates.io/crates/hashbrown/0.14.5 0.14.5 Apache-2.0 OR MIT
     https://crates.io/crates/hashbrown/0.15.2 0.15.2 Apache-2.0 OR MIT
-    https://crates.io/crates/heck/0.4.1 0.4.1 Apache-2.0 OR MIT
     https://crates.io/crates/heck/0.5.0 0.5.0 Apache-2.0 OR MIT
-    https://crates.io/crates/home/0.5.11 0.5.11 Apache-2.0 OR MIT
-    https://crates.io/crates/http/0.2.12 0.2.12 Apache-2.0 OR MIT
     https://crates.io/crates/http/1.3.1 1.3.1 Apache-2.0 OR MIT
     https://crates.io/crates/httparse/1.10.1 1.10.1 Apache-2.0 OR MIT
     https://crates.io/crates/httpdate/1.0.3 1.0.3 Apache-2.0 OR MIT
     https://crates.io/crates/humansize/2.1.3 2.1.3 Apache-2.0 OR MIT
-    https://crates.io/crates/hyper-timeout/0.4.1 0.4.1 Apache-2.0 OR MIT
+    https://crates.io/crates/hyper-timeout/0.5.2 0.5.2 Apache-2.0 OR MIT
     https://crates.io/crates/hyper-tls/0.6.0 0.6.0 Apache-2.0 OR MIT
-    https://crates.io/crates/iana-time-zone/0.1.61 0.1.61 Apache-2.0 OR MIT
+    https://crates.io/crates/iana-time-zone/0.1.63 0.1.63 Apache-2.0 OR MIT
     https://crates.io/crates/iana-time-zone-haiku/0.1.2 0.1.2 Apache-2.0 OR MIT
     https://crates.io/crates/idna/1.0.3 1.0.3 Apache-2.0 OR MIT
     https://crates.io/crates/idna_adapter/1.2.0 1.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/indexmap/1.9.3 1.9.3 Apache-2.0 OR MIT
-    https://crates.io/crates/indexmap/2.8.0 2.8.0 Apache-2.0 OR MIT
+    https://crates.io/crates/indexmap/2.9.0 2.9.0 Apache-2.0 OR MIT
     https://crates.io/crates/ipnet/2.11.0 2.11.0 Apache-2.0 OR MIT
     https://crates.io/crates/is_terminal_polyfill/1.70.1 1.70.1 Apache-2.0 OR MIT
-    https://crates.io/crates/itertools/0.10.5 0.10.5 Apache-2.0 OR MIT
     https://crates.io/crates/itertools/0.13.0 0.13.0 Apache-2.0 OR MIT
     https://crates.io/crates/itertools/0.14.0 0.14.0 Apache-2.0 OR MIT
     https://crates.io/crates/itoa/1.0.15 1.0.15 Apache-2.0 OR MIT
@@ -397,38 +383,35 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/libc/0.2.171 0.2.171 Apache-2.0 OR MIT
     https://crates.io/crates/libz-sys/1.1.22 1.1.22 Apache-2.0 OR MIT
     https://crates.io/crates/lock_api/0.4.12 0.4.12 Apache-2.0 OR MIT
-    https://crates.io/crates/log/0.4.26 0.4.26 Apache-2.0 OR MIT
-    https://crates.io/crates/match_cfg/0.1.0 0.1.0 Apache-2.0 OR MIT
+    https://crates.io/crates/log/0.4.27 0.4.27 Apache-2.0 OR MIT
     https://crates.io/crates/mime/0.3.17 0.3.17 Apache-2.0 OR MIT
     https://crates.io/crates/minimal-lexical/0.2.1 0.2.1 Apache-2.0 OR MIT
-    https://crates.io/crates/multimap/0.8.3 0.8.3 Apache-2.0 OR MIT
+    https://crates.io/crates/multimap/0.10.0 0.10.0 Apache-2.0 OR MIT
     https://crates.io/crates/native-tls/0.2.14 0.2.14 Apache-2.0 OR MIT
     https://crates.io/crates/num-conv/0.1.0 0.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/num-traits/0.2.19 0.2.19 Apache-2.0 OR MIT
     https://crates.io/crates/num_threads/0.1.7 0.1.7 Apache-2.0 OR MIT
     https://crates.io/crates/object/0.36.7 0.36.7 Apache-2.0 OR MIT
-    https://crates.io/crates/once_cell/1.21.1 1.21.1 Apache-2.0 OR MIT
+    https://crates.io/crates/once_cell/1.21.3 1.21.3 Apache-2.0 OR MIT
     https://crates.io/crates/openssl-macros/0.1.1 0.1.1 Apache-2.0 OR MIT
     https://crates.io/crates/openssl-probe/0.1.6 0.1.6 Apache-2.0 OR MIT
     https://crates.io/crates/parking_lot/0.12.3 0.12.3 Apache-2.0 OR MIT
     https://crates.io/crates/parking_lot_core/0.9.10 0.9.10 Apache-2.0 OR MIT
     https://crates.io/crates/percent-encoding/2.3.1 2.3.1 Apache-2.0 OR MIT
-    https://crates.io/crates/pest/2.7.15 2.7.15 Apache-2.0 OR MIT
-    https://crates.io/crates/pest_derive/2.7.15 2.7.15 Apache-2.0 OR MIT
-    https://crates.io/crates/pest_generator/2.7.15 2.7.15 Apache-2.0 OR MIT
-    https://crates.io/crates/pest_meta/2.7.15 2.7.15 Apache-2.0 OR MIT
-    https://crates.io/crates/petgraph/0.6.5 0.6.5 Apache-2.0 OR MIT
+    https://crates.io/crates/pest/2.8.0 2.8.0 Apache-2.0 OR MIT
+    https://crates.io/crates/pest_derive/2.8.0 2.8.0 Apache-2.0 OR MIT
+    https://crates.io/crates/pest_generator/2.8.0 2.8.0 Apache-2.0 OR MIT
+    https://crates.io/crates/pest_meta/2.8.0 2.8.0 Apache-2.0 OR MIT
+    https://crates.io/crates/petgraph/0.7.1 0.7.1 Apache-2.0 OR MIT
     https://crates.io/crates/pin-project/1.1.10 1.1.10 Apache-2.0 OR MIT
     https://crates.io/crates/pin-project-internal/1.1.10 1.1.10 Apache-2.0 OR MIT
     https://crates.io/crates/pin-project-lite/0.2.16 0.2.16 Apache-2.0 OR MIT
     https://crates.io/crates/pin-utils/0.1.0 0.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/pkg-config/0.3.32 0.3.32 Apache-2.0 OR MIT
-    https://crates.io/crates/portable-atomic/0.3.20 0.3.20 Apache-2.0 OR MIT
     https://crates.io/crates/portable-atomic/1.11.0 1.11.0 Apache-2.0 OR MIT
     https://crates.io/crates/powerfmt/0.2.0 0.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/ppv-lite86/0.2.21 0.2.21 Apache-2.0 OR MIT
-    https://crates.io/crates/prettyplease/0.1.25 0.1.25 Apache-2.0 OR MIT
-    https://crates.io/crates/prettyplease/0.2.31 0.2.31 Apache-2.0 OR MIT
+    https://crates.io/crates/prettyplease/0.2.32 0.2.32 Apache-2.0 OR MIT
     https://crates.io/crates/proc-macro-crate/3.3.0 3.3.0 Apache-2.0 OR MIT
     https://crates.io/crates/proc-macro2/1.0.94 1.0.94 Apache-2.0 OR MIT
     https://crates.io/crates/quote/1.0.40 1.0.40 Apache-2.0 OR MIT
@@ -446,6 +429,7 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/rustversion/1.0.20 1.0.20 Apache-2.0 OR MIT
     https://crates.io/crates/scopeguard/1.2.0 1.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/security-framework/2.11.1 2.11.1 Apache-2.0 OR MIT
+    https://crates.io/crates/security-framework/3.2.0 3.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/security-framework-sys/2.14.0 2.14.0 Apache-2.0 OR MIT
     https://crates.io/crates/serde/1.0.219 1.0.219 Apache-2.0 OR MIT
     https://crates.io/crates/serde_derive/1.0.219 1.0.219 Apache-2.0 OR MIT
@@ -457,24 +441,21 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/signal-hook-registry/1.4.2 1.4.2 Apache-2.0 OR MIT
     https://crates.io/crates/siphasher/1.0.1 1.0.1 Apache-2.0 OR MIT
     https://crates.io/crates/slug/0.1.6 0.1.6 Apache-2.0 OR MIT
-    https://crates.io/crates/smallvec/1.14.0 1.14.0 Apache-2.0 OR MIT
-    https://crates.io/crates/socket2/0.5.8 0.5.8 Apache-2.0 OR MIT
+    https://crates.io/crates/smallvec/1.15.0 1.15.0 Apache-2.0 OR MIT
+    https://crates.io/crates/socket2/0.5.9 0.5.9 Apache-2.0 OR MIT
     https://crates.io/crates/stable_deref_trait/1.2.0 1.2.0 Apache-2.0 OR MIT
-    https://crates.io/crates/syn/1.0.109 1.0.109 Apache-2.0 OR MIT
     https://crates.io/crates/syn/2.0.100 2.0.100 Apache-2.0 OR MIT
     https://crates.io/crates/system-configuration/0.6.1 0.6.1 Apache-2.0 OR MIT
     https://crates.io/crates/system-configuration-sys/0.6.0 0.6.0 Apache-2.0 OR MIT
-    https://crates.io/crates/tempfile/3.19.0 3.19.0 Apache-2.0 OR MIT
+    https://crates.io/crates/tempfile/3.19.1 3.19.1 Apache-2.0 OR MIT
     https://crates.io/crates/thiserror/1.0.69 1.0.69 Apache-2.0 OR MIT
     https://crates.io/crates/thiserror/2.0.12 2.0.12 Apache-2.0 OR MIT
     https://crates.io/crates/thiserror-impl/1.0.69 1.0.69 Apache-2.0 OR MIT
     https://crates.io/crates/thiserror-impl/2.0.12 2.0.12 Apache-2.0 OR MIT
     https://crates.io/crates/thread_local/1.1.8 1.1.8 Apache-2.0 OR MIT
-    https://crates.io/crates/time/0.3.40 0.3.40 Apache-2.0 OR MIT
+    https://crates.io/crates/time/0.3.41 0.3.41 Apache-2.0 OR MIT
     https://crates.io/crates/time-core/0.1.4 0.1.4 Apache-2.0 OR MIT
-    https://crates.io/crates/time-macros/0.2.21 0.2.21 Apache-2.0 OR MIT
-    https://crates.io/crates/tokio-io-timeout/1.2.0 1.2.0 Apache-2.0 OR MIT
-    https://crates.io/crates/tokio-rustls/0.23.4 0.23.4 Apache-2.0 OR MIT
+    https://crates.io/crates/time-macros/0.2.22 0.2.22 Apache-2.0 OR MIT
     https://crates.io/crates/tokio-rustls/0.26.2 0.26.2 Apache-2.0 OR MIT
     https://crates.io/crates/toml_datetime/0.6.8 0.6.8 Apache-2.0 OR MIT
     https://crates.io/crates/toml_edit/0.22.24 0.22.24 Apache-2.0 OR MIT
@@ -505,12 +486,14 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/winapi/0.3.9 0.3.9 Apache-2.0 OR MIT
     https://crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0 0.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0 0.4.0 Apache-2.0 OR MIT
-    https://crates.io/crates/windows/0.52.0 0.52.0 Apache-2.0 OR MIT
-    https://crates.io/crates/windows-core/0.52.0 0.52.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows-core/0.61.0 0.61.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows-implement/0.60.0 0.60.0 Apache-2.0 OR MIT
+    https://crates.io/crates/windows-interface/0.59.1 0.59.1 Apache-2.0 OR MIT
     https://crates.io/crates/windows-link/0.1.1 0.1.1 Apache-2.0 OR MIT
     https://crates.io/crates/windows-registry/0.4.0 0.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/windows-result/0.3.2 0.3.2 Apache-2.0 OR MIT
     https://crates.io/crates/windows-strings/0.3.1 0.3.1 Apache-2.0 OR MIT
+    https://crates.io/crates/windows-strings/0.4.0 0.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/windows-sys/0.52.0 0.52.0 Apache-2.0 OR MIT
     https://crates.io/crates/windows-sys/0.59.0 0.59.0 Apache-2.0 OR MIT
     https://crates.io/crates/windows-targets/0.52.6 0.52.6 Apache-2.0 OR MIT
@@ -540,7 +523,7 @@ Apache-2.0 OR MIT OR Zlib licenses
 The following components are provided under the Apache-2.0 OR MIT OR Zlib License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/miniz_oxide/0.8.5 0.8.5 Apache-2.0 OR MIT OR Zlib
+    https://crates.io/crates/miniz_oxide/0.8.8 0.8.8 Apache-2.0 OR MIT OR Zlib
 
 ========================================================================
 Apache-2.0) OR MIT AND (MIT licenses
@@ -567,18 +550,8 @@ The following components are provided under the ISC License. See project link fo
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://crates.io/crates/libloading/0.8.6 0.8.6 ISC
-    https://crates.io/crates/rustls-webpki/0.103.0 0.103.0 ISC
-    https://crates.io/crates/untrusted/0.7.1 0.7.1 ISC
+    https://crates.io/crates/rustls-webpki/0.103.1 0.103.1 ISC
     https://crates.io/crates/untrusted/0.9.0 0.9.0 ISC
-    https://crates.io/crates/webpki/0.22.4 0.22.4 ISC
-
-========================================================================
-ISC and OpenSSL and MIT licenses
-========================================================================
-The following components are provided under the ISC and OpenSSL and MIT License. See project link for details.
-The text of each license is also included in licenses/LICENSE-[project].txt.
-
-    https://crates.io/crates/ring/0.16.20 0.16.20 ISC and OpenSSL and MIT
 
 ========================================================================
 MIT licenses
@@ -588,10 +561,10 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://crates.io/crates/async-stream/0.3.6 0.3.6 MIT
     https://crates.io/crates/async-stream-impl/0.3.6 0.3.6 MIT
-    https://crates.io/crates/axum/0.6.20 0.6.20 MIT
-    https://crates.io/crates/axum/0.8.1 0.8.1 MIT
-    https://crates.io/crates/axum-core/0.3.4 0.3.4 MIT
-    https://crates.io/crates/axum-core/0.5.0 0.5.0 MIT
+    https://crates.io/crates/axum/0.7.9 0.7.9 MIT
+    https://crates.io/crates/axum/0.8.3 0.8.3 MIT
+    https://crates.io/crates/axum-core/0.4.5 0.4.5 MIT
+    https://crates.io/crates/axum-core/0.5.2 0.5.2 MIT
     https://crates.io/crates/bincode/2.0.1 2.0.1 MIT
     https://crates.io/crates/bincode_derive/2.0.1 2.0.1 MIT
     https://crates.io/crates/bytes/1.10.1 1.10.1 MIT
@@ -601,21 +574,17 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/duct/0.13.7 0.13.7 MIT
     https://crates.io/crates/generic-array/0.14.7 0.14.7 MIT
     https://crates.io/crates/globwalk/0.9.1 0.9.1 MIT
-    https://crates.io/crates/h2/0.3.26 0.3.26 MIT
     https://crates.io/crates/h2/0.4.8 0.4.8 MIT
-    https://crates.io/crates/hostname/0.3.1 0.3.1 MIT
-    https://crates.io/crates/hostname/0.4.0 0.4.0 MIT
-    https://crates.io/crates/http-body/0.4.6 0.4.6 MIT
+    https://crates.io/crates/hostname/0.4.1 0.4.1 MIT
     https://crates.io/crates/http-body/1.0.1 1.0.1 MIT
     https://crates.io/crates/http-body-util/0.1.3 0.1.3 MIT
-    https://crates.io/crates/hyper/0.14.32 0.14.32 MIT
     https://crates.io/crates/hyper/1.6.0 1.6.0 MIT
-    https://crates.io/crates/hyper-util/0.1.10 0.1.10 MIT
+    https://crates.io/crates/hyper-util/0.1.11 0.1.11 MIT
     https://crates.io/crates/matchers/0.1.0 0.1.0 MIT
     https://crates.io/crates/mio/1.0.3 1.0.3 MIT
     https://crates.io/crates/nom/7.1.3 7.1.3 MIT
     https://crates.io/crates/nu-ansi-term/0.46.0 0.46.0 MIT
-    https://crates.io/crates/openssl-sys/0.9.106 0.9.106 MIT
+    https://crates.io/crates/openssl-sys/0.9.107 0.9.107 MIT
     https://crates.io/crates/os_pipe/1.2.1 1.2.1 MIT
     https://crates.io/crates/overload/0.1.1 0.1.1 MIT
     https://crates.io/crates/parse-zoneinfo/0.3.1 0.3.1 MIT
@@ -623,25 +592,23 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/phf_codegen/0.11.3 0.11.3 MIT
     https://crates.io/crates/phf_generator/0.11.3 0.11.3 MIT
     https://crates.io/crates/phf_shared/0.11.3 0.11.3 MIT
-    https://crates.io/crates/rdkafka/0.32.2 0.32.2 MIT
     https://crates.io/crates/rdkafka/0.37.0 0.37.0 MIT
     https://crates.io/crates/rdkafka-sys/4.8.0+2.3.0 4.8.0+2.3.0 MIT
-    https://crates.io/crates/redox_syscall/0.5.10 0.5.10 MIT
+    https://crates.io/crates/redox_syscall/0.5.11 0.5.11 MIT
     https://crates.io/crates/schannel/0.1.27 0.1.27 MIT
     https://crates.io/crates/sharded-slab/0.1.7 0.1.7 MIT
     https://crates.io/crates/shared_child/1.0.1 1.0.1 MIT
     https://crates.io/crates/slab/0.4.9 0.4.9 MIT
-    https://crates.io/crates/spin/0.5.2 0.5.2 MIT
     https://crates.io/crates/strsim/0.11.1 0.11.1 MIT
     https://crates.io/crates/synstructure/0.13.1 0.13.1 MIT
     https://crates.io/crates/tera/1.20.0 1.20.0 MIT
-    https://crates.io/crates/tokio/1.44.1 1.44.1 MIT
+    https://crates.io/crates/tokio/1.44.2 1.44.2 MIT
     https://crates.io/crates/tokio-macros/2.5.0 2.5.0 MIT
     https://crates.io/crates/tokio-native-tls/0.3.1 0.3.1 MIT
     https://crates.io/crates/tokio-stream/0.1.17 0.1.17 MIT
     https://crates.io/crates/tokio-util/0.7.14 0.7.14 MIT
-    https://crates.io/crates/tonic/0.8.3 0.8.3 MIT
-    https://crates.io/crates/tonic-build/0.8.4 0.8.4 MIT
+    https://crates.io/crates/tonic/0.12.3 0.12.3 MIT
+    https://crates.io/crates/tonic-build/0.12.3 0.12.3 MIT
     https://crates.io/crates/tower/0.4.13 0.4.13 MIT
     https://crates.io/crates/tower/0.5.2 0.5.2 MIT
     https://crates.io/crates/tower-layer/0.3.3 0.3.3 MIT
@@ -649,15 +616,13 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/tracing/0.1.41 0.1.41 MIT
     https://crates.io/crates/tracing-attributes/0.1.28 0.1.28 MIT
     https://crates.io/crates/tracing-core/0.1.33 0.1.33 MIT
-    https://crates.io/crates/tracing-futures/0.2.5 0.2.5 MIT
     https://crates.io/crates/tracing-log/0.2.0 0.2.0 MIT
     https://crates.io/crates/tracing-subscriber/0.3.19 0.3.19 MIT
     https://crates.io/crates/try-lock/0.2.5 0.2.5 MIT
     https://crates.io/crates/valuable/0.1.1 0.1.1 MIT
     https://crates.io/crates/virtue/0.0.18 0.0.18 MIT
     https://crates.io/crates/want/0.3.1 0.3.1 MIT
-    https://crates.io/crates/which/4.4.2 4.4.2 MIT
-    https://crates.io/crates/winnow/0.7.4 0.7.4 MIT
+    https://crates.io/crates/winnow/0.7.6 0.7.6 MIT
 
 ========================================================================
 MIT AND BSD-3-Clause licenses
@@ -689,11 +654,11 @@ MulanPSL-2.0 licenses
 The following components are provided under the MulanPSL-2.0 License. See project link for details.
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
-    https://crates.io/crates/phper/0.15.1 0.15.1 MulanPSL-2.0
-    https://crates.io/crates/phper-alloc/0.15.0 0.15.0 MulanPSL-2.0
-    https://crates.io/crates/phper-build/0.15.0 0.15.0 MulanPSL-2.0
-    https://crates.io/crates/phper-macros/0.15.0 0.15.0 MulanPSL-2.0
-    https://crates.io/crates/phper-sys/0.15.0 0.15.0 MulanPSL-2.0
+    https://crates.io/crates/phper/0.16.0 0.16.0 MulanPSL-2.0
+    https://crates.io/crates/phper-alloc/0.15.1 0.15.1 MulanPSL-2.0
+    https://crates.io/crates/phper-build/0.15.1 0.15.1 MulanPSL-2.0
+    https://crates.io/crates/phper-macros/0.15.1 0.15.1 MulanPSL-2.0
+    https://crates.io/crates/phper-sys/0.15.1 0.15.1 MulanPSL-2.0
 
 ========================================================================
 Unicode-3.0 licenses
@@ -704,11 +669,11 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/icu_collections/1.5.0 1.5.0 Unicode-3.0
     https://crates.io/crates/icu_locid/1.5.0 1.5.0 Unicode-3.0
     https://crates.io/crates/icu_locid_transform/1.5.0 1.5.0 Unicode-3.0
-    https://crates.io/crates/icu_locid_transform_data/1.5.0 1.5.0 Unicode-3.0
+    https://crates.io/crates/icu_locid_transform_data/1.5.1 1.5.1 Unicode-3.0
     https://crates.io/crates/icu_normalizer/1.5.0 1.5.0 Unicode-3.0
-    https://crates.io/crates/icu_normalizer_data/1.5.0 1.5.0 Unicode-3.0
+    https://crates.io/crates/icu_normalizer_data/1.5.1 1.5.1 Unicode-3.0
     https://crates.io/crates/icu_properties/1.5.1 1.5.1 Unicode-3.0
-    https://crates.io/crates/icu_properties_data/1.5.0 1.5.0 Unicode-3.0
+    https://crates.io/crates/icu_properties_data/1.5.1 1.5.1 Unicode-3.0
     https://crates.io/crates/icu_provider/1.5.0 1.5.0 Unicode-3.0
     https://crates.io/crates/icu_provider_macros/1.5.0 1.5.0 Unicode-3.0
     https://crates.io/crates/litemap/0.7.5 0.7.5 Unicode-3.0

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -27,7 +27,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.97"
 chrono = { version = "0.4.40", default-features = false, features = ["std"] }
-clap = { version = "4.5.32", features = ["derive"] }
+clap = { version = "4.5.36", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 tera = "1.20.0"
 tracing = "0.1.41"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -32,16 +32,16 @@ kafka-reporter = ["skywalking/kafka-reporter", "rdkafka/sasl"]
 [dependencies]
 anyhow = { version = "1.0.97", features = ["backtrace"] }
 bincode = { workspace = true }
-clap = { version = "4.5.32", features = ["derive"], optional = true }
+clap = { version = "4.5.36", features = ["derive"], optional = true }
 libc = "0.2.171"
-once_cell = "1.21.1"
+once_cell = "1.21.3"
 prost = "0.13.5"
 rdkafka = { version = "0.37.0", optional = true }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
-skywalking = { version = "0.8.0", features = ["management"] }
-tokio = { version = "1.44.1", features = ["full"] }
+skywalking = { version = "0.9.0", features = ["management"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-stream = "0.1.17"
-tonic = { version = "0.8.3", features = ["tls", "tls-roots"] }
+tonic = { version = "0.12.0", features = ["tls-native-roots"] }
 tracing = { version = "0.1.41", features = ["attributes", "log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"], optional = true }
 


### PR DESCRIPTION
This pull request includes updates to various dependencies across multiple `Cargo.toml` files. The changes primarily involve updating the versions of several dependencies to their latest versions.

Dependency updates:

* Updated `hostname` from `0.4.0` to `0.4.1` in `Cargo.toml`
* Updated `once_cell` from `1.21.1` to `1.21.3` in `Cargo.toml` and `worker/Cargo.toml` [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L58-R82) [[2]](diffhunk://#diff-68efb2e92ef637adfc679d138884adddb0379af94d13e49767102c548859444fL35-R44)
* Updated `phper` from `0.15.1` to `0.16.0` in `Cargo.toml`
* Updated `skywalking` from `0.8.0` to `0.9.0` in `Cargo.toml` and `worker/Cargo.toml` [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L58-R82) [[2]](diffhunk://#diff-68efb2e92ef637adfc679d138884adddb0379af94d13e49767102c548859444fL35-R44)
* Updated `tokio` from `1.44.1` to `1.44.2` in `Cargo.toml` and `worker/Cargo.toml` [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L58-R82) [[2]](diffhunk://#diff-68efb2e92ef637adfc679d138884adddb0379af94d13e49767102c548859444fL35-R44)
* Updated `tonic` from `0.8.3` to `0.12.0` in `Cargo.toml` and `worker/Cargo.toml` [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L58-R82) [[2]](diffhunk://#diff-68efb2e92ef637adfc679d138884adddb0379af94d13e49767102c548859444fL35-R44)
* Updated `clap` from `4.5.32` to `4.5.36` in `scripts/Cargo.toml` and `worker/Cargo.toml` [[1]](diffhunk://#diff-01909391d9dbbf32f402b5a94929e5a3409a96c96437fb6402cb442136b9fb2bL30-R30) [[2]](diffhunk://#diff-68efb2e92ef637adfc679d138884adddb0379af94d13e49767102c548859444fL35-R44)
* Updated `phper-build` from `0.15.0` to `0.15.1` in `Cargo.toml`
* Updated `axum` from `0.8.1` to `0.8.3` in `Cargo.toml`