### PR TITLE
Bump version to 1.0.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "skywalking-php"
-version = "1.0.0-dev"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "skywalking-php-worker"
-version = "1.0.0-dev"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-dev"
+version = "1.0.0"
 authors = ["Apache Software Foundation", "jmjoy <jmjoy@apache.org>", "Yanlong He <heyanlong@apache.org>"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
This pull request includes a version update for the `Cargo.toml` file, changing the version from "1.0.0-dev" to "1.0.0".

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L24-R24): Updated the version from "1.0.0-dev" to "1.0.0".